### PR TITLE
Harden upload path handling in /files/upload

### DIFF
--- a/open_terminal/main.py
+++ b/open_terminal/main.py
@@ -918,9 +918,14 @@ async def upload_file(
             status_code=400, detail="Provide either 'url' or a file upload."
         )
 
+    filename = os.path.basename(filename) or "upload"
+    target_dir = os.path.abspath(directory)
+
     try:
-        await aiofiles.os.makedirs(directory, exist_ok=True)
-        path = os.path.join(directory, filename)
+        await aiofiles.os.makedirs(target_dir, exist_ok=True)
+        path = os.path.abspath(os.path.join(target_dir, filename))
+        if os.path.commonpath([target_dir, path]) != target_dir:
+            raise HTTPException(status_code=400, detail="Invalid upload filename")
         async with aiofiles.open(path, "wb") as f:
             await f.write(content)
     except OSError as e:


### PR DESCRIPTION
## What changed
- Sanitized uploaded filenames with `os.path.basename(...)` for both URL and multipart uploads.
- Normalized upload destination to an absolute directory path before writing.
- Added a `commonpath` guard to ensure the final write path stays inside the requested upload directory.

## Why
- `UploadFile.filename` can contain path segments from clients. Joining it directly can allow writes outside the intended destination.
- Normalizing and validating the resolved path makes `/files/upload` behavior consistent with other file endpoints and avoids accidental path traversal.

## Testing
- `source .venv/bin/activate && pytest -q`
- Tests: not run (no tests found)
