### PR TITLE
adding ROS and jabas customisations

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         platform:
           - linux/amd64
-          - linux/arm64
+          #- linux/arm64
     permissions:
       contents: read
       packages: write

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,11 @@
-FROM python:3.12
+# FROM python:3.12
+
+ARG ROS_DISTRO=humble
+
+FROM ros:${ROS_DISTRO}
+
+SHELL ["/bin/bash", "-c"]
+
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     # Core utilities
@@ -25,6 +32,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     procps htop lsof strace sysstat \
     sudo tmux screen \
     ca-certificates gnupg apt-transport-https \
+    python3-pip python3-venv \
+    ros-${ROS_DISTRO}-ros-base \
     && rm -rf /var/lib/apt/lists/*
 
 # Node.js (LTS)


### PR DESCRIPTION
This pull request updates the Docker setup to use a ROS-based image instead of the standard Python image, and adjusts the workflow and dependencies accordingly. The main changes focus on transitioning to ROS, updating the base image and installed packages, and modifying the GitHub Actions workflow to reflect these changes.

**Docker image and dependencies update:**

* Changed the base image in `Dockerfile` from `python:3.12` to `ros:${ROS_DISTRO}` (with `ROS_DISTRO` defaulting to `humble`), and set the shell to use `/bin/bash` for compatibility with ROS.
* Added installation of `python3-pip`, `python3-venv`, and `ros-${ROS_DISTRO}-ros-base` to the list of packages in the Docker build process.

**Workflow adjustments:**

* Commented out the `linux/arm64` platform in the `.github/workflows/docker.yml` matrix, likely due to compatibility issues with the new ROS-based image.