### PR TITLE
fix: reap zombie processes via tini PID 1 and os.killpg() for process groups

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     zip unzip tar gzip bzip2 xz-utils zstd p7zip-full \
     # System
     procps htop lsof strace sysstat \
-    sudo tmux screen \
+    sudo tmux screen tini \
     ca-certificates gnupg apt-transport-https \
     # Capabilities (needed for setcap on Python binary)
     libcap2-bin \
@@ -67,5 +67,5 @@ EXPOSE 8000
 
 COPY entrypoint.sh /app/entrypoint.sh
 
-ENTRYPOINT ["/app/entrypoint.sh"]
+ENTRYPOINT ["/usr/bin/tini", "--", "/app/entrypoint.sh"]
 CMD ["run"]

--- a/open_terminal/main.py
+++ b/open_terminal/main.py
@@ -1310,11 +1310,18 @@ if ENABLE_TERMINAL:
                 pass
             process = session["process"]
             if process.poll() is None:
-                process.terminate()
+                try:
+                    os.killpg(process.pid, signal.SIGTERM)
+                except ProcessLookupError:
+                    pass
                 try:
                     process.wait(timeout=2)
                 except subprocess.TimeoutExpired:
-                    process.kill()
+                    try:
+                        os.killpg(process.pid, signal.SIGKILL)
+                    except ProcessLookupError:
+                        pass
+                    process.wait()
 
         elif backend == "winpty":
             pty_proc = session["pty_process"]

--- a/open_terminal/utils/runner.py
+++ b/open_terminal/utils/runner.py
@@ -110,10 +110,11 @@ class PtyRunner(ProcessRunner):
         os.write(self._master_fd, data)
 
     def kill(self, force: bool = False) -> None:
-        if force:
-            self._process.kill()
-        else:
-            self._process.send_signal(signal.SIGTERM)
+        sig = signal.SIGKILL if force else signal.SIGTERM
+        try:
+            os.killpg(self._process.pid, sig)
+        except ProcessLookupError:
+            pass
 
     async def wait(self) -> int:
         return await asyncio.to_thread(self._process.wait)


### PR DESCRIPTION
## Problem

When running in Docker, two related zombie/orphan process issues exist:

1. **No init process**: `entrypoint.sh` uses `exec open-terminal "$@"`, which
   makes the Python/uvicorn process run directly as PID 1. Python has no
   `SIGCHLD` handler to reap orphaned grandchildren (e.g. processes spawned
   inside a terminal session that then loses its parent). These accumulate as
   zombie processes indefinitely.

2. **Incomplete process group cleanup**: `_cleanup_session` and
   `PtyRunner.kill()` sent signals only to the direct shell PID, not to the
   entire process group. Background processes started inside a terminal session
   (e.g. `sleep 100 &`) were left running as orphans. Additionally,
   `_cleanup_session` called `process.kill()` but never called `process.wait()`
   afterwards, so the kernel kept the PCB in zombie state `Z`.

## Fix

**`Dockerfile`** — add `tini` as PID 1:
```dockerfile
sudo tmux screen tini \
...
ENTRYPOINT ["/usr/bin/tini", "--", "/app/entrypoint.sh"]
```

## Testing

Built the Docker image and verified with a smoke test:

- tini is PID 1 ✓
- DELETE /execute/{id} kills all child processes in the group, no zombies ✓
- DELETE /api/terminals/{id} cleans up the shell session completely ✓
- WebSocket disconnect triggers full session cleanup, background jobs killed ✓
