### PR TITLE
Warn users about the implications of docker socket access

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ docker run -d --name open-terminal -p 8000:8000 \
 ```
 
 > [!CAUTION]
-> Mounting the Docker socket gives the container full access to the host's Docker daemon. Only do this in trusted environments.
+> Mounting the Docker socket is the equivalent of giving the container root on the host system. Only do this in trusted environments.
 
 For full control, fork the repo, edit the [Dockerfile](Dockerfile), and build your own image:
 


### PR DESCRIPTION
When docker is running in its standard rootful mode, having access to the docker socket  gives the equivalent of root access on the host system.  Given this project is likely to be run by some people who aren't familiar with this relatively non-intuitive fact about rootful docker, it seems prudent to update the warning to make it clear what this access means.