### PR TITLE
fix: enforce env/_FILE mutual exclusivity for empty values

### DIFF
--- a/open_terminal/env.py
+++ b/open_terminal/env.py
@@ -16,7 +16,7 @@ def _resolve_file_env(var: str, default: str = "") -> str:
     value = os.environ.get(var)
     file_path = os.environ.get(f"{var}_FILE")
 
-    if value and file_path:
+    if value is not None and file_path is not None:
         raise ValueError(
             f"Both {var} and {var}_FILE are set, but they are mutually exclusive."
         )

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,0 +1,38 @@
+import pytest
+
+from open_terminal.env import _resolve_file_env
+
+
+def test_resolve_file_env_reads_direct_env(monkeypatch):
+    monkeypatch.setenv("TEST_SECRET", "direct-value")
+    monkeypatch.delenv("TEST_SECRET_FILE", raising=False)
+
+    assert _resolve_file_env("TEST_SECRET") == "direct-value"
+
+
+def test_resolve_file_env_reads_file_value(monkeypatch, tmp_path):
+    secret_file = tmp_path / "secret.txt"
+    secret_file.write_text("file-secret\n")
+
+    monkeypatch.delenv("TEST_SECRET", raising=False)
+    monkeypatch.setenv("TEST_SECRET_FILE", str(secret_file))
+
+    assert _resolve_file_env("TEST_SECRET") == "file-secret"
+
+
+def test_resolve_file_env_raises_when_both_set_even_if_empty(monkeypatch, tmp_path):
+    secret_file = tmp_path / "secret.txt"
+    secret_file.write_text("file-secret")
+
+    monkeypatch.setenv("TEST_SECRET", "")
+    monkeypatch.setenv("TEST_SECRET_FILE", str(secret_file))
+
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        _resolve_file_env("TEST_SECRET")
+
+
+def test_resolve_file_env_returns_default_when_unset(monkeypatch):
+    monkeypatch.delenv("TEST_SECRET", raising=False)
+    monkeypatch.delenv("TEST_SECRET_FILE", raising=False)
+
+    assert _resolve_file_env("TEST_SECRET", default="fallback") == "fallback"


### PR DESCRIPTION
## What changed
- Fixed `_resolve_file_env` in `open_terminal/env.py` to treat an explicitly set empty environment value as "set" when checking `<VAR>` vs `<VAR>_FILE` mutual exclusivity.
- Added `tests/test_env.py` with coverage for:
  - direct env value resolution,
  - `_FILE`-based secret resolution,
  - exclusivity error when both are set (including empty-string env values),
  - default fallback behavior.

## Why
- The previous check used truthiness (`if value and file_path`), which incorrectly treated `VAR=""` as if `VAR` were unset.
- This could silently accept conflicting configuration and read secrets from `<VAR>_FILE` even when `VAR` was explicitly provided (as empty), making deployments harder to reason about.

## Insight / Why this matters
- **Root cause:** Python truthiness conflates "unset" and "set to empty string" for env values in boolean checks.
- **Why it is easy to miss:** most setups use non-empty values, so the edge case appears only in container/runtime configurations that intentionally set empty env vars.
- **Practical impact:** configuration behavior is now deterministic and aligned with secret-env conventions; ambiguous dual-source config fails fast instead of silently choosing one source.
- **Tradeoff:** this is a stricter interpretation and can surface previously hidden misconfigurations early; that is safer than implicit fallback for secret material.

## Testing
- ✅ `scripts/clone_and_test.sh open-webui/open-terminal`
  - Result: `4 passed`
- ✅ `. .venv/bin/activate && pytest -q tests/test_env.py`
  - Result: `4 passed`
