### PR TITLE
fix: GET terminals return null

### DIFF
--- a/open_terminal/main.py
+++ b/open_terminal/main.py
@@ -1496,7 +1496,7 @@ if ENABLE_TERMINAL:
                 fs = get_filesystem(request)
 
                 # Use per-session cwd if available, else fall back to home
-                session_id = request.headers.get("x-session-id")
+                session_id = request.headers.get("x-session-id", session_id)
                 session_cwd = _get_session_cwd(session_id, fs) if session_id else None
 
                 if fs.username:


### PR DESCRIPTION
When getting HTTP headers, it may return None, which will cause open-webui to fail to connect to the terminal