### PR TITLE
fix: pass API key as Bearer token in MCP server httpx client

### DIFF
--- a/open_terminal/mcp_server.py
+++ b/open_terminal/mcp_server.py
@@ -1,7 +1,15 @@
 """MCP server — exposes every FastAPI endpoint as an MCP tool."""
 
 from fastmcp import FastMCP
-
 from open_terminal.main import app
+from open_terminal.env import API_KEY
 
-mcp = FastMCP.from_fastapi(app=app, name="Open Terminal")
+mcp = FastMCP.from_fastapi(
+    app=app,
+    name="Open Terminal",
+    httpx_client_kwargs={
+        "headers": {
+            "Authorization": f"Bearer {API_KEY}",
+        }
+    },
+)


### PR DESCRIPTION
FastMCP.from_fastapi() uses an internal httpx client to call the FastAPI routes. Without auth headers, every tool call (run_command, read_file, etc.) hits the verify_api_key guard and returns 401.

Fixes tool calls returning: 'HTTP error 401: Unauthorized - Invalid API key'

closes: #105 