### PR TITLE
Feature: Optional adding the OS user to a OS group

### DIFF
--- a/open_terminal/env.py
+++ b/open_terminal/env.py
@@ -151,6 +151,11 @@ USER_PREFIX = os.environ.get(
     config.get("user_prefix", ""),
 )
 
+USER_GROUP = os.environ.get(
+    "OPEN_TERMINAL_USER_GROUP",
+    config.get("user_group", ""),
+)
+
 UVICORN_LOOP = os.environ.get(
     "OPEN_TERMINAL_UVICORN_LOOP",
     config.get("uvicorn_loop", "auto"),

--- a/open_terminal/utils/user_isolation.py
+++ b/open_terminal/utils/user_isolation.py
@@ -87,6 +87,8 @@ def ensure_os_user(username: str) -> str:
     for reads while other provisioned users still get ``Permission denied``.
     Returns the home directory path.
     """
+    from open_terminal.env import USER_GROUP
+
     try:
         pw = pwd.getpwnam(username)
         return pw.pw_dir
@@ -100,6 +102,9 @@ def ensure_os_user(username: str) -> str:
     # different UID assignment) and set permissions.
     _run_privileged(["chown", "-R", f"{username}:{username}", home_dir])
     _run_privileged(["chmod", "2770", home_dir])
+    # Optionally add the OS user to a shared group
+    if USER_GROUP:
+        _run_privileged(["usermod", "-aG", USER_GROUP, username])
     # Add the server process user to the new user's group so Python can
     # read files natively without subprocess.
     server_user = os.getenv("USER", "user")


### PR DESCRIPTION
This PR adds an OS user to an existing OS group. This feature is used to further restrict sudo privileges by limiting them to runas members of a specific group only. Here is an example :

The USER_GROUP variable have `otusers` as value. The USER_PREFIX have `ot_` as value. The service run as `openterminal` user. My sudoers file is the following. 

```
Defaults:openterminal !requiretty, !use_pty, !pam_session

Cmnd_Alias OPENTERMINAL_CMDS = \
    /usr/sbin/useradd ^-m -s /bin/bash ot_[a-z0-9_]{1,32}$, \
    /usr/bin/chown ^(-R )?ot_[a-z0-9_]{1,32}:ot_[a-z0-9_]{1,32} /home/ot_[a-z0-9_]{1,32}(/[a-zA-ZÀÂÄÉÈÊËÎÏÔÖÙÛÜÇàâäéèêëîïôöùûüç0-9_][a-zA-ZÀÂÄÉÈÊËÎÏÔÖÙÛÜÇàâäéèêëîïôöùûüç0-9%&_.+\$()\ -]*)*/?$, \
    /usr/bin/chmod ^2770 /home/ot_[a-z0-9_]{1,32}(/[a-zA-ZÀÂÄÉÈÊËÎÏÔÖÙÛÜÇàâäéèêëîïôöùûüç0-9_][a-zA-ZÀÂÄÉÈÊËÎÏÔÖÙÛÜÇàâäéèêëîïôöùûüç0-9%&_.+\$()\ -]*)*/?$, \
    /usr/bin/chmod ^g\+w /home/ot_[a-z0-9_]{1,32}(/[a-zA-ZÀÂÄÉÈÊËÎÏÔÖÙÛÜÇàâäéèêëîïôöùûüç0-9_][a-zA-ZÀÂÄÉÈÊËÎÏÔÖÙÛÜÇàâäéèêëîïôöùûüç0-9%&_.+\$()\ -]*)*/?$, \
    /usr/sbin/usermod ^-aG otusers ot_[a-z0-9_]{1,32}$, \
    /usr/sbin/usermod ^-aG ot_[a-z0-9_]{1,32} openterminal$

openterminal ALL=(root) NOPASSWD: OPENTERMINAL_CMDS

openterminal ALL=(%otusers) NOPASSWD: ALL

```

The service's privileges are constrained on two fronts:

-  When acting as root, it is restricted to the explicitly defined OPENTERMINAL_CMDS allowlist, covering only the necessary useradd, chown, chmod, and usermod operations.
- When impersonating other users, it can only do so for members of the otusers group, preventing any lateral movement to unrelated system accounts.

This ensures the service cannot gain unrestricted root access or impersonate arbitrary users, significantly limiting its attack surface. I also constrained the systemd service, but this is out of scope of this PR and doesn't require patch.