### PR TITLE
security: strip OPEN_TERMINAL_* from subprocess env

### DIFF
--- a/open_terminal/env.py
+++ b/open_terminal/env.py
@@ -3,6 +3,24 @@ import os
 from open_terminal import config
 
 
+def sanitized_environ(extra: dict | None = None) -> dict:
+    """Return ``os.environ`` with all ``OPEN_TERMINAL_*`` variables stripped.
+
+    Used when spawning subprocesses (user shells, executed commands, notebook
+    kernels, etc.) so that child processes cannot observe internal
+    configuration — notably ``OPEN_TERMINAL_API_KEY`` and its
+    ``OPEN_TERMINAL_API_KEY_FILE`` Docker-secret variant.
+
+    *extra* is merged on top of the sanitized base.  Caller-supplied values
+    win, including any ``OPEN_TERMINAL_*`` keys the caller explicitly chooses
+    to re-introduce.
+    """
+    env = {k: v for k, v in os.environ.items() if not k.startswith("OPEN_TERMINAL_")}
+    if extra:
+        env.update(extra)
+    return env
+
+
 def _resolve_file_env(var: str, default: str = "") -> str:
     """Resolve an environment variable with Docker-secrets ``_FILE`` support.
 

--- a/open_terminal/main.py
+++ b/open_terminal/main.py
@@ -24,7 +24,7 @@ from fastapi.responses import JSONResponse, Response
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from pydantic import BaseModel, Field
 
-from open_terminal.env import API_KEY, BINARY_FILE_MIME_PREFIXES, CORS_ALLOWED_ORIGINS, ENABLE_NOTEBOOKS, ENABLE_SYSTEM_PROMPT, ENABLE_TERMINAL, EXECUTE_DESCRIPTION, EXECUTE_TIMEOUT, LOG_DIR, MAX_TERMINAL_SESSIONS, MULTI_USER, OPEN_TERMINAL_INFO, PROCESS_LOG_RETENTION, SESSION_CWD_TTL, SYSTEM_PROMPT, TERMINAL_TERM
+from open_terminal.env import API_KEY, BINARY_FILE_MIME_PREFIXES, CORS_ALLOWED_ORIGINS, ENABLE_NOTEBOOKS, ENABLE_SYSTEM_PROMPT, ENABLE_TERMINAL, EXECUTE_DESCRIPTION, EXECUTE_TIMEOUT, LOG_DIR, MAX_TERMINAL_SESSIONS, MULTI_USER, OPEN_TERMINAL_INFO, PROCESS_LOG_RETENTION, SESSION_CWD_TTL, SYSTEM_PROMPT, TERMINAL_TERM, sanitized_environ
 from open_terminal.utils.runner import PipeRunner, ProcessRunner, create_runner
 from open_terminal.utils.fs import UserFS
 
@@ -1125,7 +1125,7 @@ async def execute(
     session_cwd = _get_session_cwd(session_id, fs) if session_id else None
     cwd = fs.resolve_path(request.cwd, cwd=session_cwd) if request.cwd else (session_cwd or fs.home)
 
-    subprocess_env = {**os.environ, **request.env} if request.env else None
+    subprocess_env = sanitized_environ(request.env)
     runner = await create_runner(
         request.command, cwd, subprocess_env, run_as_user=fs.username
     )
@@ -1521,7 +1521,7 @@ if ENABLE_TERMINAL:
                     shell_cmd = [os.environ.get("SHELL", "/bin/sh")]
                     cwd = session_cwd or os.getcwd()
 
-                spawn_env = os.environ.copy()
+                spawn_env = sanitized_environ()
                 spawn_env.setdefault("TERM", TERMINAL_TERM)
                 process = subprocess.Popen(
                     shell_cmd,
@@ -1552,7 +1552,7 @@ if ENABLE_TERMINAL:
 
         else:  # winpty
             shell = os.environ.get("COMSPEC", "cmd.exe")
-            spawn_env = os.environ.copy()
+            spawn_env = sanitized_environ()
             spawn_env.setdefault("TERM", TERMINAL_TERM)
             pty_proc = _WinPtyProcess.spawn(
                 [shell],

--- a/open_terminal/utils/runner.py
+++ b/open_terminal/utils/runner.py
@@ -7,6 +7,8 @@ import subprocess
 import time
 from abc import ABC, abstractmethod
 
+from open_terminal.env import sanitized_environ
+
 try:
     import fcntl
     import pty
@@ -207,9 +209,7 @@ class WinPtyRunner(ProcessRunner):
     """Spawn a command under a Windows pseudo-terminal (ConPTY via pywinpty)."""
 
     def __init__(self, command: str, cwd: str | None, env: dict | None):
-        spawn_env = os.environ.copy()
-        if env:
-            spawn_env.update(env)
+        spawn_env = sanitized_environ(env)
 
         # Determine the executable and arguments.
         # PtyProcess.spawn expects a list: [executable, *args]


### PR DESCRIPTION
User-spawned shells and commands inherited the full parent environment, including `OPEN_TERMINAL_API_KEY`. A user running `env | grep OPEN_TERMINAL_` inside an `/execute` command or `/api/terminals` session could read internal configuration meant only for the server process.

This is the minimal, conservative fix:
- `OPEN_TERMINAL_*` keys are stripped. Other variables such as `PATH`, `HOME`, `USER`, `SHELL`, `TERM`, `LANG`, etc pass through unchanged, so user shells continue to feel normal.
- Caller-supplied `env` in `POST /execute` still wins on collision — authenticated callers can explicitly re-add any variable.

Tested in my environment — REST API with OpenWebUI
 
Another option was introducing a prefix convention to fully separate server variables from sandbox variables — e.g. `SANDBOX_API_KEY` on the server side becomes `API_KEY` inside the user's shell. This would give stronger isolation but is likely a breaking change: operators currently set env vars in their Dockerfile / compose / launch scripts and expect them to pass through to user commands. For that reason I did not choose this approach.