### PR TITLE
retire codex-gemma operational usage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# OpenTerminal local bare-metal defaults
+OPEN_TERMINAL_HOST=127.0.0.1
+OPEN_TERMINAL_PORT=8010
+OPEN_TERMINAL_CWD=/home/trotsky/Projects
+OPEN_TERMINAL_CORS_ALLOWED_ORIGINS=http://127.0.0.1:8080,http://localhost:8080
+OPEN_TERMINAL_LOG_DIR=/home/trotsky/.local/state/open-terminal/logs
+# Optional context hint shown in OpenAPI description
+OPEN_TERMINAL_INFO=Local execution harness for coding/system-ops tasks.

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ See local docs:
 
 - `docs/LOCAL_BASELINE.md`
 - `docs/SAFETY_BOUNDARIES.md`
+- `docs/OTX_ROUTER_SETUP.md` (cross-host target router from one CLI session)
 
 ### Docker (recommended)
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,36 @@ You can run it two ways:
 
 ## Getting Started
 
+### Local Bare-Metal + systemd (no container)
+
+This repo can run as a standalone local service with `systemd --user`.
+
+```bash
+cd /home/trotsky/Projects/open-terminal
+./scripts/setup-local.sh
+./scripts/install-user-service.sh
+./scripts/start.sh
+```
+
+Check service status/logs:
+
+```bash
+./scripts/status.sh
+./scripts/logs.sh
+```
+
+Default local baseline:
+
+- bind: `127.0.0.1`
+- port: `8010`
+- working directory: `/home/trotsky/Projects`
+- API key file: `~/.config/open-terminal/api_key`
+
+See local docs:
+
+- `docs/LOCAL_BASELINE.md`
+- `docs/SAFETY_BOUNDARIES.md`
+
 ### Docker (recommended)
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -41,12 +41,15 @@ open-terminal
 Inside REPL:
 
 - `/` shows command palette
+- `/menu` opens an interactive command picker (fzf if available; numbered fallback)
 - `/<prefix>` filters commands
 - `TAB` cycles command completion
 - `/run "<task>"` starts an async codex-gemma worker job
 - `/jobs` and `/job status|wait|result|logs|cancel <job_id>` manage async jobs
 - `/contract strict|off` toggles response-contract enforcement (default: strict)
 - `/statusline on|off` toggles prompt status line (`mode|model|cwd`)
+
+Strict contract mode includes auto-repair retries and task-shape validation for constrained prompts (for example exact-output and single-code-block coding tasks).
 
 Default local baseline:
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,23 @@ Check service status/logs:
 ./scripts/logs.sh
 ```
 
+OpenTerminal control CLI (global command after install script):
+
+```bash
+open-terminal -h
+open-terminal
+```
+
+Inside REPL:
+
+- `/` shows command palette
+- `/<prefix>` filters commands
+- `TAB` cycles command completion
+- `/run "<task>"` starts an async codex-gemma worker job
+- `/jobs` and `/job status|wait|result|logs|cancel <job_id>` manage async jobs
+- `/contract strict|off` toggles response-contract enforcement (default: strict)
+- `/statusline on|off` toggles prompt status line (`mode|model|cwd`)
+
 Default local baseline:
 
 - bind: `127.0.0.1`

--- a/README.md
+++ b/README.md
@@ -44,12 +44,17 @@ Inside REPL:
 - `/menu` opens an interactive command picker (fzf if available; numbered fallback)
 - `/<prefix>` filters commands
 - `TAB` cycles command completion
-- `/run "<task>"` starts an async codex-gemma worker job
-- `/jobs` and `/job status|wait|result|logs|cancel <job_id>` manage async jobs
+- `/run "<task>"` is retired; use packet-mediated local-worker delegation instead
+- `/jobs` and `/job status|wait|result|logs|cancel <job_id>` are retired historical surfaces
 - `/contract strict|off` toggles response-contract enforcement (default: strict)
 - `/statusline on|off` toggles prompt status line (`mode|model|cwd`)
 
 Strict contract mode includes auto-repair retries and task-shape validation for constrained prompts (for example exact-output and single-code-block coding tasks).
+
+Historical note:
+
+- `codex-gemma` is no longer part of the active Open Terminal operational path.
+- The historical wrapper only remains for explicit benchmark or migration use via `CODEX_GEMMA_ALLOW_HISTORICAL=1`.
 
 Default local baseline:
 

--- a/docs/CUTOVER_2026-05-10.md
+++ b/docs/CUTOVER_2026-05-10.md
@@ -1,0 +1,22 @@
+# Cutover Checkpoint - 2026-05-10
+
+## Summary
+
+- OpenTerminal moved from Docker container runtime to user-level `systemd`.
+- OpenWebUI terminal integration removed (decoupled operation).
+- OpenTerminal now runs locally at `http://127.0.0.1:8010`.
+
+## Applied Actions
+
+1. Removed Docker container `open-terminal`.
+2. Started and validated `systemctl --user open-terminal.service`.
+3. Recreated `open-webui` container without `TERMINAL_SERVER_CONNECTIONS`.
+4. Added a dedicated decoupled OpenWebUI launcher script in `open-webui-custom`.
+
+## Verification
+
+- `systemctl --user status open-terminal` => active/running.
+- `GET /health` on `127.0.0.1:8010` => `{"status":"ok"}`.
+- `POST /execute` + `GET /execute/{id}/status` => command completed with exit code `0`.
+- OpenWebUI healthy on `127.0.0.1:8080/health`.
+- OpenWebUI container env has no `TERMINAL_SERVER_CONNECTIONS`.

--- a/docs/LOCAL_BASELINE.md
+++ b/docs/LOCAL_BASELINE.md
@@ -56,7 +56,8 @@ This document defines the local, standalone baseline for OpenTerminal as an agen
 - Model-side mitigation policy pack (via `codex-gemma ask`):
   - strict task-class detection (`exact_literal`, `exact_one_code_block`, `group_anagrams_contract`)
   - bounded auto-repair retries
-  - optional fallback routing to Qwen endpoint on strict failure
+  - single-model lock default `on` (prevents cross-model fallback by default)
+  - optional fallback routing to Qwen endpoint on strict failure only when explicitly enabled
   - deterministic trace logging in `~/.local/state/open-terminal/codex-gemma-trace.log`
 
 ## Known Limitations

--- a/docs/LOCAL_BASELINE.md
+++ b/docs/LOCAL_BASELINE.md
@@ -53,6 +53,11 @@ This document defines the local, standalone baseline for OpenTerminal as an agen
   - `/run <task>`
   - `/jobs`
   - `/job status|wait|result|logs|cancel <job_id>`
+- Model-side mitigation policy pack (via `codex-gemma ask`):
+  - strict task-class detection (`exact_literal`, `exact_one_code_block`, `group_anagrams_contract`)
+  - bounded auto-repair retries
+  - optional fallback routing to Qwen endpoint on strict failure
+  - deterministic trace logging in `~/.local/state/open-terminal/codex-gemma-trace.log`
 
 ## Known Limitations
 

--- a/docs/LOCAL_BASELINE.md
+++ b/docs/LOCAL_BASELINE.md
@@ -54,11 +54,12 @@ This document defines the local, standalone baseline for OpenTerminal as an agen
   - `/jobs`
   - `/job status|wait|result|logs|cancel <job_id>`
 - Model-side mitigation policy pack (via `codex-gemma ask`):
-  - strict task-class detection (`exact_literal`, `exact_one_code_block`, `group_anagrams_contract`)
-  - bounded auto-repair retries
+  - strict task-class detection (`exact_literal`, `exact_one_code_block`, `group_anagrams_contract`, `pass_fail_only`, `valid_json_only`, `bullet_list_only`)
+  - bounded auto-repair retries with per-task retry caps
   - single-model lock default `on` (prevents cross-model fallback by default)
   - optional fallback routing to Qwen endpoint on strict failure only when explicitly enabled
   - deterministic trace logging in `~/.local/state/open-terminal/codex-gemma-trace.log`
+  - failure taxonomy codes in trace output (for example: `schema.missing_signature`, `format.invalid_json`, `request.endpoint_error`)
 - Explicit benchmark profile (via `codex-gemma benchmark`):
   - discoverable benchmark-only command surface
   - can target `gemma` or `qwen2`

--- a/docs/LOCAL_BASELINE.md
+++ b/docs/LOCAL_BASELINE.md
@@ -34,6 +34,24 @@ This document defines the local, standalone baseline for OpenTerminal as an agen
 - Run as user service (no root service files by default)
 - Do not mount `/` into the runtime (container-only behavior removed in this mode)
 
+## OpenTerminal CLI Baseline (Operator UX)
+
+- Chat-first REPL: text input sends chat messages by default.
+- Slash-command command mode: enter commands with `/...`.
+- Slash discoverability:
+  - `/` lists all commands
+  - `/<prefix>` filters command list
+  - `TAB` cycles slash command completions
+- Persistent status prompt (default enabled):
+  - `open-terminal[<mode>|<model>|<cwd>]>`
+- Contract mode (default `strict`):
+  - validates strict output-format prompts
+  - auto-retries with repair prompt on format failure
+- Async orchestration jobs (via `codex-gemma`):
+  - `/run <task>`
+  - `/jobs`
+  - `/job status|wait|result|logs|cancel <job_id>`
+
 ## Known Limitations
 
 - OpenTerminal itself does not enforce approval prompts for destructive shell commands; that policy must come from the calling agent/workflow.

--- a/docs/LOCAL_BASELINE.md
+++ b/docs/LOCAL_BASELINE.md
@@ -49,18 +49,21 @@ This document defines the local, standalone baseline for OpenTerminal as an agen
   - validates strict output-format prompts
   - auto-retries with repair prompt on format failure
   - enforces stronger coding-task shape checks (single code block, required signature/tests in constrained prompts)
-- Async orchestration jobs (via `codex-gemma`):
+
+## Historical Codex-Gemma Notes (retired from active use)
+
+- Async orchestration jobs (historical codex-gemma surface):
   - `/run <task>`
   - `/jobs`
   - `/job status|wait|result|logs|cancel <job_id>`
-- Model-side mitigation policy pack (via `codex-gemma ask`):
+- Model-side mitigation policy pack (historical `codex-gemma ask` path):
   - strict task-class detection (`exact_literal`, `exact_one_code_block`, `group_anagrams_contract`, `pass_fail_only`, `valid_json_only`, `bullet_list_only`)
   - bounded auto-repair retries with per-task retry caps
   - single-model lock default `on` (prevents cross-model fallback by default)
   - optional fallback routing to Qwen endpoint on strict failure only when explicitly enabled
   - deterministic trace logging in `~/.local/state/open-terminal/codex-gemma-trace.log`
   - failure taxonomy codes in trace output (for example: `schema.missing_signature`, `format.invalid_json`, `request.endpoint_error`)
-- Explicit benchmark profile (via `codex-gemma benchmark`):
+- Explicit benchmark profile (historical `codex-gemma benchmark` surface):
   - discoverable benchmark-only command surface
   - can target `gemma` or `qwen2`
   - disables single-model lock for controlled benchmark sessions only

--- a/docs/LOCAL_BASELINE.md
+++ b/docs/LOCAL_BASELINE.md
@@ -64,6 +64,10 @@ This document defines the local, standalone baseline for OpenTerminal as an agen
   - discoverable benchmark-only command surface
   - can target `gemma` or `qwen2`
   - disables single-model lock for controlled benchmark sessions only
+- BA-Midnight bounded readiness loop:
+  - `scripts/midnight-probe-loop --repo <midnight-gateway-path> --cycles 3 --sleep-sec 20`
+  - optional execute mode: append `--execute` to run fee-bearing deploy probe only after readiness gate opens (`availableCoinCountEnd > 0`)
+  - writes run log + summary under `~/.local/state/open-terminal/midnight-probe-loop/`
 
 ## Known Limitations
 

--- a/docs/LOCAL_BASELINE.md
+++ b/docs/LOCAL_BASELINE.md
@@ -39,7 +39,8 @@ This document defines the local, standalone baseline for OpenTerminal as an agen
 - Chat-first REPL: text input sends chat messages by default.
 - Slash-command command mode: enter commands with `/...`.
 - Slash discoverability:
-  - `/` lists all commands
+  - `/` opens interactive command picker (fzf when installed; numbered fallback)
+  - `/menu` opens interactive command picker explicitly
   - `/<prefix>` filters command list
   - `TAB` cycles slash command completions
 - Persistent status prompt (default enabled):
@@ -47,6 +48,7 @@ This document defines the local, standalone baseline for OpenTerminal as an agen
 - Contract mode (default `strict`):
   - validates strict output-format prompts
   - auto-retries with repair prompt on format failure
+  - enforces stronger coding-task shape checks (single code block, required signature/tests in constrained prompts)
 - Async orchestration jobs (via `codex-gemma`):
   - `/run <task>`
   - `/jobs`

--- a/docs/LOCAL_BASELINE.md
+++ b/docs/LOCAL_BASELINE.md
@@ -1,0 +1,41 @@
+# OpenTerminal Local Baseline (No Containers)
+
+This document defines the local, standalone baseline for OpenTerminal as an agentic coding and system-ops harness.
+
+## Current State Found (2026-05-10)
+
+- Source repo: `/home/trotsky/Projects/open-terminal`
+- Repo is already git-initialized.
+- OpenTerminal is currently running via Docker as container `open-terminal` on host port `8010`.
+- OpenWebUI is configured to call it via `TERMINAL_SERVER_CONNECTIONS` at `http://127.0.0.1:8010`.
+- Local model endpoints from B70 lab:
+  - Gemma endpoint: `http://127.0.0.1:8000/v1`
+  - Qwen endpoint: `http://127.0.0.1:8091/v1` (currently marked disabled in `local-model-endpoints.z490.json`)
+  - OpenVINO test endpoint (documented in B70 README): `http://127.0.0.1:8090`
+
+## Standalone Role Split
+
+- OpenWebUI role: chat/research/RAG UI.
+- OpenTerminal role: execution harness for shell workflows, coding changes, and system operations.
+- Integration with OpenWebUI is optional and should remain loose.
+
+## Runtime Requirements (Bare Metal)
+
+- Python `>=3.11` (host currently has 3.12.3)
+- `uv` (present) or equivalent venv tooling
+- Dependencies from `pyproject.toml`
+- User-level `systemd` (`systemctl --user`)
+
+## Baseline Safety Defaults
+
+- Bind host to `127.0.0.1` (local-only)
+- Run with explicit `--cwd /home/trotsky/Projects`
+- Keep API key in `~/.config/open-terminal/api_key`
+- Run as user service (no root service files by default)
+- Do not mount `/` into the runtime (container-only behavior removed in this mode)
+
+## Known Limitations
+
+- OpenTerminal itself does not enforce approval prompts for destructive shell commands; that policy must come from the calling agent/workflow.
+- `--cwd` sets server process working directory but does not hard sandbox all command paths.
+- If OpenWebUI keeps polling a stale terminal URL/key, logs will show repeated auth or connectivity errors until updated.

--- a/docs/LOCAL_BASELINE.md
+++ b/docs/LOCAL_BASELINE.md
@@ -59,6 +59,10 @@ This document defines the local, standalone baseline for OpenTerminal as an agen
   - single-model lock default `on` (prevents cross-model fallback by default)
   - optional fallback routing to Qwen endpoint on strict failure only when explicitly enabled
   - deterministic trace logging in `~/.local/state/open-terminal/codex-gemma-trace.log`
+- Explicit benchmark profile (via `codex-gemma benchmark`):
+  - discoverable benchmark-only command surface
+  - can target `gemma` or `qwen2`
+  - disables single-model lock for controlled benchmark sessions only
 
 ## Known Limitations
 

--- a/docs/OTX_ROUTER_SETUP.md
+++ b/docs/OTX_ROUTER_SETUP.md
@@ -116,6 +116,20 @@ Tail logs from target:
 scripts/otx --target nuc logs --unit open-terminal --lines 200
 ```
 
+## One-Command Cross-Host Benchmark
+
+Run the policy-path benchmark on both targets and refresh local comparison artifacts:
+
+```bash
+scripts/otx-benchmark-crosshost
+```
+
+Optional flags:
+
+```bash
+scripts/otx-benchmark-crosshost --retries 3 --wait 300 --local z490 --remote nuc
+```
+
 ## Safety Notes
 
 - `otx edit` shows a diff by default and asks before applying.

--- a/docs/OTX_ROUTER_SETUP.md
+++ b/docs/OTX_ROUTER_SETUP.md
@@ -98,6 +98,24 @@ Run command:
 scripts/otx --target nuc run -- "git status"
 ```
 
+Run command in login shell (recommended when target relies on shell profile setup):
+
+```bash
+scripts/otx --target nuc run --login-shell -- "node -v"
+```
+
+Run Node/NPM command on NVM-based target without editing system PATH:
+
+```bash
+scripts/otx --target nuc run --login-shell --node-bin /home/trotsky/.nvm/versions/node/v22.22.0/bin -- "npm -v"
+```
+
+Source a remote env file before execution (keeps secrets on the target host):
+
+```bash
+scripts/otx --target nuc run --source-env /home/trotsky/.local/share/ba-midnight/probe-wallet-seed.env --node-bin /home/trotsky/.nvm/versions/node/v22.22.0/bin -- "cd /home/trotsky/Projects/ba-midnight/midnight-gateway && npm run -s probe:wallet-sdk-dust-sync-diagnostics"
+```
+
 Read file:
 
 ```bash

--- a/docs/OTX_ROUTER_SETUP.md
+++ b/docs/OTX_ROUTER_SETUP.md
@@ -1,0 +1,87 @@
+# OTX Router Setup (One Session, Two Machines)
+
+`otx` is a target router for OpenTerminal. It lets you run commands and edit files on either host from one CLI without hopping terminals.
+
+## Purpose
+
+- one control plane from Z490
+- explicit target dispatch (`z490`, `nuc`)
+- command execution + file read/write/edit through OpenTerminal APIs
+
+## Prereqs
+
+1. OpenTerminal running on both hosts (systemd user service preferred).
+2. API key available for each host.
+3. Network path from this machine to remote OpenTerminal URL.
+
+## Config
+
+Create:
+
+`~/.config/open-terminal/targets.json`
+
+Example:
+
+```json
+{
+  "default": "z490",
+  "targets": {
+    "z490": {
+      "base_url": "http://127.0.0.1:8010",
+      "api_key": "REPLACE_LOCAL_KEY",
+      "cwd": "/home/trotsky/Projects",
+      "session_id": "otx-z490"
+    },
+    "nuc": {
+      "base_url": "http://NUC_IP_OR_HOSTNAME:8010",
+      "api_key": "REPLACE_NUC_KEY",
+      "cwd": "/home/<user>/Projects",
+      "session_id": "otx-nuc"
+    }
+  }
+}
+```
+
+## Commands
+
+List targets:
+
+```bash
+scripts/otx --config ~/.config/open-terminal/targets.json targets
+```
+
+Health check remote:
+
+```bash
+scripts/otx --target nuc health
+```
+
+Run command:
+
+```bash
+scripts/otx --target nuc run -- "git status"
+```
+
+Read file:
+
+```bash
+scripts/otx --target nuc read /home/<user>/Projects/repo/README.md
+```
+
+Edit file through local `$EDITOR` and write back:
+
+```bash
+scripts/otx --target nuc edit /home/<user>/Projects/repo/path/to/file.py
+```
+
+Tail logs from target:
+
+```bash
+scripts/otx --target nuc logs --unit open-terminal --lines 200
+```
+
+## Safety Notes
+
+- `otx edit` shows a diff by default and asks before applying.
+- keep `targets.json` private (`chmod 600`) because it contains API keys.
+- prefer target-specific `cwd` values to avoid accidental writes outside project roots.

--- a/docs/OTX_ROUTER_SETUP.md
+++ b/docs/OTX_ROUTER_SETUP.md
@@ -42,6 +42,42 @@ Example:
 }
 ```
 
+## Recommended NUC Connectivity (Loopback + SSH Tunnel)
+
+Keep NUC OpenTerminal bound to `127.0.0.1:8010` and expose it on Z490 through a user tunnel.
+
+Example user service on Z490:
+
+`~/.config/systemd/user/otx-nuc-tunnel.service`
+
+```ini
+[Unit]
+Description=OTX SSH tunnel to NUC OpenTerminal
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/ssh -NT -i %h/.ssh/id_ed25519_z490_to_trotsky -o ExitOnForwardFailure=yes -o ServerAliveInterval=20 -o ServerAliveCountMax=3 -L 18010:127.0.0.1:8010 trotsky@100.68.242.114
+Restart=always
+RestartSec=2
+
+[Install]
+WantedBy=default.target
+```
+
+Enable it:
+
+```bash
+systemctl --user daemon-reload
+systemctl --user enable --now otx-nuc-tunnel.service
+systemctl --user status otx-nuc-tunnel.service
+```
+
+Then configure NUC target as:
+
+- `base_url`: `http://127.0.0.1:18010`
+
 ## Commands
 
 List targets:

--- a/docs/SAFETY_BOUNDARIES.md
+++ b/docs/SAFETY_BOUNDARIES.md
@@ -1,0 +1,20 @@
+# Safety Boundaries (Baseline)
+
+These are operational boundaries for this harness baseline:
+
+1. Default working area is `/home/trotsky/Projects`.
+2. Avoid destructive commands unless explicitly approved for the current task.
+3. Do not edit `/etc`, `/usr`, `/var`, or service unit files without confirmation.
+4. Prefer `git diff` before and after significant edits.
+5. Log important operational changes in commit messages and `journalctl` output.
+
+## Optional Local Guard Helper
+
+Use `scripts/guarded-run.sh` for manual command execution with basic path/risk checks.
+
+Example:
+
+```bash
+scripts/guarded-run.sh "git status"
+scripts/guarded-run.sh "rm -rf /tmp/test" --force
+```

--- a/docs/examples/targets.json.example
+++ b/docs/examples/targets.json.example
@@ -1,0 +1,17 @@
+{
+  "default": "z490",
+  "targets": {
+    "z490": {
+      "base_url": "http://127.0.0.1:8010",
+      "api_key": "REPLACE_LOCAL_OPEN_TERMINAL_API_KEY",
+      "cwd": "/home/trotsky/Projects",
+      "session_id": "otx-z490"
+    },
+    "nuc": {
+      "base_url": "http://NUC_IP_OR_HOSTNAME:8010",
+      "api_key": "REPLACE_NUC_OPEN_TERMINAL_API_KEY",
+      "cwd": "/home/USER/Projects",
+      "session_id": "otx-nuc"
+    }
+  }
+}

--- a/scripts/codex-gemma
+++ b/scripts/codex-gemma
@@ -6,7 +6,7 @@ GEMMA_UNIT="${GEMMA_UNIT:-z490-gemma-llama.service}"
 QWEN_ENDPOINT="${QWEN_ENDPOINT:-http://127.0.0.1:8091/v1}"
 CODEX_GEMMA_POLICY_MODE="${CODEX_GEMMA_POLICY_MODE:-strict}"
 CODEX_GEMMA_MAX_RETRIES="${CODEX_GEMMA_MAX_RETRIES:-2}"
-CODEX_GEMMA_FALLBACK_ON_FAIL="${CODEX_GEMMA_FALLBACK_ON_FAIL:-1}"
+CODEX_GEMMA_FALLBACK_ON_FAIL="${CODEX_GEMMA_FALLBACK_ON_FAIL:-0}"
 CG_STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/open-terminal"
 CG_TRACE_FILE="${CG_STATE_DIR}/codex-gemma-trace.log"
 CG_JOBS_DIR="${CG_STATE_DIR}/codex-gemma-jobs"
@@ -20,7 +20,7 @@ codex-gemma - bridge for Codex CLI to message/control local Gemma backend
 Usage:
   codex-gemma status
   codex-gemma models
-  codex-gemma ask [--policy strict|off] [--retries N] [--fallback none|qwen2] "your prompt"
+  codex-gemma ask [--policy strict|off] [--retries N] [--fallback none|qwen2] [--single-model-lock on|off] "your prompt"
   codex-gemma ask --file /path/to/prompt.txt
   codex-gemma orchestrate "task" [--max-refine N] [--async]
   codex-gemma jobs
@@ -40,7 +40,7 @@ Env overrides:
   CODEX_GEMMA_NOTIFY_CMD (optional completion hook; receives "<job_id> <status>")
   CODEX_GEMMA_POLICY_MODE (strict|off, default: strict)
   CODEX_GEMMA_MAX_RETRIES (default: 2)
-  CODEX_GEMMA_FALLBACK_ON_FAIL (0|1, default: 1)
+  CODEX_GEMMA_FALLBACK_ON_FAIL (0|1, default: 0)
 EOF
 }
 
@@ -201,19 +201,30 @@ read_prompt_arg() {
 ask_cmd() {
   local policy="$CODEX_GEMMA_POLICY_MODE"
   local retries="$CODEX_GEMMA_MAX_RETRIES"
-  local fallback="qwen2"
+  local fallback="none"
+  local single_model_lock="on"
   local args=()
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --policy) shift; policy="${1:-strict}" ;;
       --retries) shift; retries="${1:-2}" ;;
-      --fallback) shift; fallback="${1:-qwen2}" ;;
+      --fallback) shift; fallback="${1:-none}" ;;
+      --single-model-lock) shift; single_model_lock="${1:-on}" ;;
       *) args+=("$1") ;;
     esac
     shift || true
   done
   if ! [[ "$retries" =~ ^[0-9]+$ ]]; then
     echo "Invalid --retries value: $retries" >&2
+    return 1
+  fi
+
+  if [[ "$single_model_lock" != "on" && "$single_model_lock" != "off" ]]; then
+    echo "Invalid --single-model-lock value: $single_model_lock (expected on|off)" >&2
+    return 1
+  fi
+  if [[ "$fallback" != "none" && "$fallback" != "qwen2" ]]; then
+    echo "Invalid --fallback value: $fallback (expected none|qwen2)" >&2
     return 1
   fi
 
@@ -229,7 +240,7 @@ ask_cmd() {
   local assistant=""
   local validation_msg=""
 
-  append_trace "POLICY" "mode=$policy retries=$retries task_class=$task_class endpoint=$endpoint"
+  append_trace "POLICY" "mode=$policy retries=$retries task_class=$task_class endpoint=$endpoint fallback=$fallback single_model_lock=$single_model_lock"
   while (( attempt <= retries )); do
     assistant="$(chat_once "$endpoint" "$model" "$current_prompt")" || {
       append_trace "ASK_ERROR" "attempt=$attempt endpoint=$endpoint"
@@ -252,7 +263,7 @@ ask_cmd() {
     attempt=$((attempt + 1))
   done
 
-  if [[ "$policy" == "strict" && "$CODEX_GEMMA_FALLBACK_ON_FAIL" == "1" && "$fallback" == "qwen2" ]]; then
+  if [[ "$single_model_lock" == "off" && "$policy" == "strict" && "$CODEX_GEMMA_FALLBACK_ON_FAIL" == "1" && "$fallback" == "qwen2" ]]; then
     local fb_endpoint="$QWEN_ENDPOINT"
     local fb_model=""
     fb_model="$(resolve_model_id_for_endpoint "$fb_endpoint" 2>/dev/null || true)"
@@ -276,6 +287,9 @@ ask_cmd() {
   fi
 
   echo "Request failed strict policy after retries."
+  if [[ "$single_model_lock" == "on" ]]; then
+    echo "Fallback not attempted due to single-model lock."
+  fi
   if [[ -n "$validation_msg" ]]; then
     echo "Last validation error: $validation_msg"
   fi

--- a/scripts/codex-gemma
+++ b/scripts/codex-gemma
@@ -7,6 +7,7 @@ QWEN_ENDPOINT="${QWEN_ENDPOINT:-http://127.0.0.1:8091/v1}"
 CODEX_GEMMA_POLICY_MODE="${CODEX_GEMMA_POLICY_MODE:-strict}"
 CODEX_GEMMA_MAX_RETRIES="${CODEX_GEMMA_MAX_RETRIES:-2}"
 CODEX_GEMMA_FALLBACK_ON_FAIL="${CODEX_GEMMA_FALLBACK_ON_FAIL:-0}"
+CODEX_GEMMA_MIDNIGHT_GUARD="${CODEX_GEMMA_MIDNIGHT_GUARD:-1}"
 CG_STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/open-terminal"
 CG_TRACE_FILE="${CG_STATE_DIR}/codex-gemma-trace.log"
 CG_JOBS_DIR="${CG_STATE_DIR}/codex-gemma-jobs"
@@ -43,6 +44,7 @@ Env overrides:
   CODEX_GEMMA_POLICY_MODE (strict|off, default: strict)
   CODEX_GEMMA_MAX_RETRIES (default: 2)
   CODEX_GEMMA_FALLBACK_ON_FAIL (0|1, default: 0)
+  CODEX_GEMMA_MIDNIGHT_GUARD (0|1, default: 1)
 EOF
 }
 
@@ -124,6 +126,8 @@ elif "def group_anagrams(words: list[str]) -> list[list[str]]" in p:
     print("group_anagrams_contract")
 elif "exactly one runnable python code block" in p:
     print("exact_one_code_block")
+elif "midnight" in p and ("command" in p or "experiment" in p or "probe:" in p):
+    print("midnight_experiment_plan")
 else:
     print("general")
 PY
@@ -184,6 +188,49 @@ elif task == "bullet_list_only":
     for ln in lines:
         if ln not in bullet_lines:
             fail("expected bullet list only")
+elif task == "midnight_experiment_plan":
+    allowed_scripts = {
+        "probe:wallet-sdk-fee-bearing-deploy",
+        "probe:wallet-sdk-dustless-deploy",
+        "probe:wallet-sdk-proof-server-replay",
+        "probe:wallet-sdk-facade-component-sync",
+        "probe:wallet-sdk-dust-sync-diagnostics",
+        "probe:wallet-sdk-shielded-sync-diagnostics",
+        "probe:wallet-sdk-unshielded-sync-diagnostics",
+        "probe:wallet-sdk-post-registration-dust-state",
+        "probe:wallet-sdk-dust-warm-state",
+        "probe:wallet-sdk-dust-registration",
+    }
+    candidate = cand.strip()
+    fenced = re.match(r"^```(?:json)?\s*([\s\S]*?)\s*```$", candidate, flags=re.IGNORECASE)
+    if fenced:
+        candidate = fenced.group(1).strip()
+    if not candidate.startswith("{"):
+        mobj = re.search(r"(\{[\s\S]*\})", candidate)
+        if mobj:
+            candidate = mobj.group(1).strip()
+    try:
+        obj = json.loads(candidate)
+    except Exception as exc:
+        fail(f"expected valid JSON object: {exc}")
+    if not isinstance(obj, dict):
+        fail("expected JSON object")
+    for key in ("objective", "command", "expected_signal", "stop_condition"):
+        if key not in obj or not isinstance(obj[key], str) or not obj[key].strip():
+            fail(f"missing or invalid key: {key}")
+    cmd = obj["command"].strip()
+    if "\n" in cmd:
+        fail("command must be single-line")
+    if "npm run -s " not in cmd:
+        fail("command must use npm run -s")
+    m = re.search(r"npm run -s (probe:wallet-sdk-[a-z0-9\\-]+)", cmd)
+    if not m:
+        fail("command must target probe:wallet-sdk-* script")
+    script = m.group(1)
+    if script not in allowed_scripts:
+        fail(f"script not allowlisted: {script}")
+    if "solana " in cmd.lower():
+        fail("non-midnight tooling disallowed")
 print("ok")
 PY
 }
@@ -214,6 +261,14 @@ elif "expected at least two bullet lines" in msg:
     print("format.missing_bullets")
 elif "expected bullet list only" in msg:
     print("format.non_bullet_lines")
+elif "script not allowlisted" in msg:
+    print("midnight.command_not_allowlisted")
+elif "command must target probe:wallet-sdk-* script" in msg:
+    print("midnight.command_not_probe_script")
+elif "command must use npm run -s" in msg:
+    print("midnight.command_missing_npm_probe")
+elif "expected valid json object" in msg:
+    print("midnight.invalid_json_schema")
 else:
     print(f"validation.{task}.failed")
 PY
@@ -228,6 +283,7 @@ retry_cap_for_task_class() {
     bullet_list_only) echo 2 ;;
     exact_one_code_block) echo 2 ;;
     group_anagrams_contract) echo 2 ;;
+    midnight_experiment_plan) echo 1 ;;
     *) echo "$CODEX_GEMMA_MAX_RETRIES" ;;
   esac
 }
@@ -245,6 +301,45 @@ Invalid prior response:
 $invalid_output
 
 Return corrected output only. No commentary.
+EOF
+}
+
+build_midnight_guard_prompt() {
+  local original_prompt="$1"
+  cat <<EOF
+You are operating in BA-Midnight guarded mode.
+Return EXACTLY one JSON object with keys:
+- objective
+- command
+- expected_signal
+- stop_condition
+
+Hard rules:
+- command must be a single line
+- command must use: npm run -s probe:wallet-sdk-*
+- do not use non-Midnight tools (no Solana, no generic sweep scripts)
+- one bounded experiment only
+
+User request:
+$original_prompt
+EOF
+}
+
+build_midnight_repair_prompt() {
+  local original_prompt="$1"
+  local invalid_output="$2"
+  cat <<EOF
+Your prior answer violated BA-Midnight guarded mode.
+
+Return EXACTLY one JSON object with keys objective, command, expected_signal, stop_condition.
+Use exactly one allowlisted command with npm run -s probe:wallet-sdk-*.
+No commentary.
+
+Original request:
+$original_prompt
+
+Invalid output:
+$invalid_output
 EOF
 }
 
@@ -310,9 +405,17 @@ ask_cmd() {
   fi
   local attempt=0
   local current_prompt="$prompt"
+  local base_prompt="$prompt"
   local assistant=""
   local validation_msg=""
   local validation_code=""
+  local midnight_guard_primed=0
+
+  if [[ "$task_class" == "midnight_experiment_plan" && "$CODEX_GEMMA_MIDNIGHT_GUARD" == "1" ]]; then
+    current_prompt="$(build_midnight_guard_prompt "$prompt")"
+    base_prompt="$current_prompt"
+    midnight_guard_primed=1
+  fi
 
   append_trace "POLICY" "mode=$policy retries=$retries task_class=$task_class class_retry_cap=$class_retry_cap endpoint=$endpoint fallback=$fallback single_model_lock=$single_model_lock"
   while (( attempt <= retries )); do
@@ -334,7 +437,11 @@ ask_cmd() {
     fi
     validation_code="$(error_code_for_validation_msg "$task_class" "$validation_msg")"
     append_trace "VALIDATION_FAIL" "attempt=$attempt task_class=$task_class code=$validation_code detail=$validation_msg"
-    current_prompt="$(build_repair_prompt "$prompt" "$assistant")"
+    if [[ "$task_class" == "midnight_experiment_plan" && "$midnight_guard_primed" == "1" ]]; then
+      current_prompt="$(build_midnight_repair_prompt "$base_prompt" "$assistant")"
+    else
+      current_prompt="$(build_repair_prompt "$prompt" "$assistant")"
+    fi
     attempt=$((attempt + 1))
   done
 

--- a/scripts/codex-gemma
+++ b/scripts/codex-gemma
@@ -114,6 +114,12 @@ import sys
 p=sys.argv[1].lower()
 if "print exactly this string and nothing else:" in p:
     print("exact_literal")
+elif "respond only pass or fail" in p:
+    print("pass_fail_only")
+elif "return valid json" in p or "output valid json" in p:
+    print("valid_json_only")
+elif "return exactly" in p and "bullets" in p:
+    print("bullet_list_only")
 elif "def group_anagrams(words: list[str]) -> list[list[str]]" in p:
     print("group_anagrams_contract")
 elif "exactly one runnable python code block" in p:
@@ -128,7 +134,7 @@ validate_response() {
   local prompt="$2"
   local candidate="$3"
   python3 - "$task_class" "$prompt" "$candidate" <<'PY'
-import re,sys
+import json,re,sys
 task=sys.argv[1]
 prompt=sys.argv[2]
 cand=sys.argv[3]
@@ -162,8 +168,68 @@ elif task == "exact_literal":
         target = m.group(1).strip()
         if cand.strip() != target:
             fail(f"expected exact literal {target!r}")
+elif task == "pass_fail_only":
+    if cand.strip() not in {"PASS","FAIL"}:
+        fail("expected exactly PASS or FAIL")
+elif task == "valid_json_only":
+    try:
+        json.loads(cand)
+    except Exception as exc:
+        fail(f"expected valid JSON: {exc}")
+elif task == "bullet_list_only":
+    lines=[ln.strip() for ln in cand.splitlines() if ln.strip()]
+    bullet_lines=[ln for ln in lines if re.match(r"^[-*]\s+\S+", ln)]
+    if len(bullet_lines) < 2:
+        fail("expected at least two bullet lines")
+    for ln in lines:
+        if ln not in bullet_lines:
+            fail("expected bullet list only")
 print("ok")
 PY
+}
+
+error_code_for_validation_msg() {
+  local task_class="$1"
+  local msg="$2"
+  python3 - "$task_class" "$msg" <<'PY'
+import sys
+task,msg=sys.argv[1],sys.argv[2].lower()
+if "expected exactly one fenced code block" in msg:
+    print("format.multiple_or_missing_codeblock")
+elif "expected no text outside code block" in msg:
+    print("format.text_outside_codeblock")
+elif "missing exact function signature" in msg:
+    print("schema.missing_signature")
+elif "missing docstring" in msg:
+    print("schema.missing_docstring")
+elif "expected exactly 5 assert" in msg:
+    print("schema.assert_count_mismatch")
+elif "expected exact literal" in msg:
+    print("format.literal_mismatch")
+elif "expected exactly pass or fail" in msg:
+    print("format.pass_fail_only")
+elif "expected valid json" in msg:
+    print("format.invalid_json")
+elif "expected at least two bullet lines" in msg:
+    print("format.missing_bullets")
+elif "expected bullet list only" in msg:
+    print("format.non_bullet_lines")
+else:
+    print(f"validation.{task}.failed")
+PY
+}
+
+retry_cap_for_task_class() {
+  local task_class="$1"
+  case "$task_class" in
+    exact_literal) echo 1 ;;
+    pass_fail_only) echo 1 ;;
+    valid_json_only) echo 2 ;;
+    bullet_list_only) echo 2 ;;
+    exact_one_code_block) echo 2 ;;
+    group_anagrams_contract) echo 2 ;;
+    *) echo "$CODEX_GEMMA_MAX_RETRIES" ;;
+  esac
 }
 
 build_repair_prompt() {
@@ -237,15 +303,21 @@ ask_cmd() {
   model="$(resolve_model_id_for_endpoint "$endpoint")"
   local task_class
   task_class="$(detect_task_class "$prompt")"
+  local class_retry_cap
+  class_retry_cap="$(retry_cap_for_task_class "$task_class")"
+  if (( retries > class_retry_cap )); then
+    retries="$class_retry_cap"
+  fi
   local attempt=0
   local current_prompt="$prompt"
   local assistant=""
   local validation_msg=""
+  local validation_code=""
 
-  append_trace "POLICY" "mode=$policy retries=$retries task_class=$task_class endpoint=$endpoint fallback=$fallback single_model_lock=$single_model_lock"
+  append_trace "POLICY" "mode=$policy retries=$retries task_class=$task_class class_retry_cap=$class_retry_cap endpoint=$endpoint fallback=$fallback single_model_lock=$single_model_lock"
   while (( attempt <= retries )); do
     assistant="$(chat_once "$endpoint" "$model" "$current_prompt")" || {
-      append_trace "ASK_ERROR" "attempt=$attempt endpoint=$endpoint"
+      append_trace "ASK_ERROR" "attempt=$attempt endpoint=$endpoint code=request.endpoint_error"
       break
     }
     if [[ "$policy" != "strict" || "$task_class" == "general" ]]; then
@@ -260,7 +332,8 @@ ask_cmd() {
       printf '%s\n' "$assistant"
       return 0
     fi
-    append_trace "VALIDATION_FAIL" "attempt=$attempt task_class=$task_class detail=$validation_msg"
+    validation_code="$(error_code_for_validation_msg "$task_class" "$validation_msg")"
+    append_trace "VALIDATION_FAIL" "attempt=$attempt task_class=$task_class code=$validation_code detail=$validation_msg"
     current_prompt="$(build_repair_prompt "$prompt" "$assistant")"
     attempt=$((attempt + 1))
   done
@@ -274,14 +347,18 @@ ask_cmd() {
       current_prompt="$prompt"
       attempt=0
       while (( attempt <= retries )); do
-        assistant="$(chat_once "$fb_endpoint" "$fb_model" "$current_prompt")" || break
+        assistant="$(chat_once "$fb_endpoint" "$fb_model" "$current_prompt")" || {
+          append_trace "FALLBACK_ASK_ERROR" "attempt=$attempt endpoint=$fb_endpoint code=request.fallback_endpoint_error"
+          break
+        }
         if [[ "$task_class" == "general" ]] || validation_msg="$(validate_response "$task_class" "$prompt" "$assistant" 2>&1)"; then
           append_trace "CODEX->QWEN prompt" "$current_prompt"
           append_trace "QWEN->CODEX response" "$assistant"
           printf '%s\n' "$assistant"
           return 0
         fi
-        append_trace "FALLBACK_VALIDATION_FAIL" "attempt=$attempt task_class=$task_class detail=$validation_msg"
+        validation_code="$(error_code_for_validation_msg "$task_class" "$validation_msg")"
+        append_trace "FALLBACK_VALIDATION_FAIL" "attempt=$attempt task_class=$task_class code=$validation_code detail=$validation_msg"
         current_prompt="$(build_repair_prompt "$prompt" "$assistant")"
         attempt=$((attempt + 1))
       done
@@ -293,6 +370,9 @@ ask_cmd() {
     echo "Fallback not attempted due to single-model lock."
   fi
   if [[ -n "$validation_msg" ]]; then
+    if [[ -n "$validation_code" ]]; then
+      echo "Failure code: $validation_code"
+    fi
     echo "Last validation error: $validation_msg"
   fi
   return 1

--- a/scripts/codex-gemma
+++ b/scripts/codex-gemma
@@ -13,6 +13,8 @@ Usage:
   codex-gemma models
   codex-gemma ask "your prompt"
   codex-gemma ask --file /path/to/prompt.txt
+  codex-gemma watch "your prompt"
+  codex-gemma watch --file /path/to/prompt.txt
   codex-gemma start|stop|restart
   codex-gemma logs [N]
   codex-gemma endpoint
@@ -100,6 +102,55 @@ stop_cmd() { systemctl --user stop "$GEMMA_UNIT"; }
 restart_cmd() { systemctl --user restart "$GEMMA_UNIT"; }
 logs_cmd() { journalctl --user -u "$GEMMA_UNIT" -n "${1:-120}" --no-pager; }
 
+watch_cmd() {
+  local prompt=""
+  if [[ "${1:-}" == "--file" ]]; then
+    if [[ -z "${2:-}" || ! -f "$2" ]]; then
+      echo "Missing prompt file."
+      exit 1
+    fi
+    prompt="$(cat "$2")"
+  else
+    prompt="${1:-}"
+  fi
+
+  if [[ -z "$prompt" ]]; then
+    echo "Prompt is empty."
+    exit 1
+  fi
+
+  local tmp_log
+  tmp_log="$(mktemp)"
+  echo "Starting live log tail for $GEMMA_UNIT ..."
+  journalctl --user -u "$GEMMA_UNIT" -f --no-pager > "$tmp_log" 2>&1 &
+  local tail_pid=$!
+
+  # Give tail a moment to attach before sending request.
+  sleep 0.4
+
+  echo
+  echo ">>> codex-gemma ask"
+  if ! ask_cmd "$prompt"; then
+    kill "$tail_pid" >/dev/null 2>&1 || true
+    wait "$tail_pid" 2>/dev/null || true
+    echo
+    echo "Request failed. Recent logs:"
+    tail -n 80 "$tmp_log" || true
+    rm -f "$tmp_log"
+    return 1
+  fi
+
+  # Capture a short post-request window, then stop tail and print recent lines.
+  sleep 1.2
+  kill "$tail_pid" >/dev/null 2>&1 || true
+  wait "$tail_pid" 2>/dev/null || true
+
+  echo
+  echo ">>> recent $GEMMA_UNIT logs"
+  tail -n 80 "$tmp_log" || true
+  rm -f "$tmp_log"
+}
+
 main() {
   case "${1:-help}" in
     status) status_cmd ;;
@@ -107,6 +158,10 @@ main() {
     ask)
       shift || true
       ask_cmd "$@"
+      ;;
+    watch)
+      shift || true
+      watch_cmd "$@"
       ;;
     start) start_cmd ;;
     stop) stop_cmd ;;

--- a/scripts/codex-gemma
+++ b/scripts/codex-gemma
@@ -5,7 +5,8 @@ GEMMA_ENDPOINT="${GEMMA_ENDPOINT:-http://127.0.0.1:8000/v1}"
 GEMMA_UNIT="${GEMMA_UNIT:-z490-gemma-llama.service}"
 CG_STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/open-terminal"
 CG_TRACE_FILE="${CG_STATE_DIR}/codex-gemma-trace.log"
-mkdir -p "$CG_STATE_DIR"
+CG_JOBS_DIR="${CG_STATE_DIR}/codex-gemma-jobs"
+mkdir -p "$CG_STATE_DIR" "$CG_JOBS_DIR"
 touch "$CG_TRACE_FILE"
 
 usage() {
@@ -17,6 +18,10 @@ Usage:
   codex-gemma models
   codex-gemma ask "your prompt"
   codex-gemma ask --file /path/to/prompt.txt
+  codex-gemma orchestrate "task" [--max-refine N] [--async]
+  codex-gemma jobs
+  codex-gemma status-job <job_id>
+  codex-gemma wait <job_id>
   codex-gemma follow
   codex-gemma watch "your prompt"
   codex-gemma watch --file /path/to/prompt.txt
@@ -27,6 +32,7 @@ Usage:
 Env overrides:
   GEMMA_ENDPOINT (default: http://127.0.0.1:8000/v1)
   GEMMA_UNIT     (default: z490-gemma-llama.service)
+  CODEX_GEMMA_NOTIFY_CMD (optional completion hook; receives "<job_id> <status>")
 EOF
 }
 
@@ -51,22 +57,27 @@ models_cmd() {
   echo
 }
 
-ask_cmd() {
+read_prompt_arg() {
   local prompt=""
   if [[ "${1:-}" == "--file" ]]; then
     if [[ -z "${2:-}" || ! -f "$2" ]]; then
-      echo "Missing prompt file."
-      exit 1
+      echo "Missing prompt file." >&2
+      return 1
     fi
     prompt="$(cat "$2")"
   else
     prompt="${1:-}"
   fi
-
   if [[ -z "$prompt" ]]; then
-    echo "Prompt is empty."
-    exit 1
+    echo "Prompt is empty." >&2
+    return 1
   fi
+  printf '%s\n' "$prompt"
+}
+
+ask_cmd() {
+  local prompt
+  prompt="$(read_prompt_arg "${1:-}" "${2:-}")" || exit 1
 
   local model
   model="$(curl -fsS "${GEMMA_ENDPOINT%/}/models" | python3 -c '
@@ -122,22 +133,259 @@ append_trace() {
   } >> "$CG_TRACE_FILE"
 }
 
-watch_cmd() {
-  local prompt=""
-  if [[ "${1:-}" == "--file" ]]; then
-    if [[ -z "${2:-}" || ! -f "$2" ]]; then
-      echo "Missing prompt file."
-      exit 1
-    fi
-    prompt="$(cat "$2")"
-  else
-    prompt="${1:-}"
-  fi
+job_meta_file() { printf '%s/%s.meta\n' "$CG_JOBS_DIR" "$1"; }
+job_log_file() { printf '%s/%s.log\n' "$CG_JOBS_DIR" "$1"; }
+job_result_file() { printf '%s/%s.result.md\n' "$CG_JOBS_DIR" "$1"; }
 
-  if [[ -z "$prompt" ]]; then
-    echo "Prompt is empty."
+job_set_status() {
+  local job_id="$1"
+  local status="$2"
+  local meta
+  meta="$(job_meta_file "$job_id")"
+  if [[ -f "$meta" ]]; then
+    awk -v s="$status" '
+      BEGIN{done=0}
+      /^status=/{print "status=" s; done=1; next}
+      {print}
+      END{if(!done) print "status=" s}
+    ' "$meta" > "${meta}.tmp"
+    mv "${meta}.tmp" "$meta"
+  fi
+}
+
+notify_completion() {
+  local job_id="$1"
+  local status="$2"
+  if [[ -n "${CODEX_GEMMA_NOTIFY_CMD:-}" ]]; then
+    bash -lc "$CODEX_GEMMA_NOTIFY_CMD \"$job_id\" \"$status\"" >/dev/null 2>&1 || true
+  fi
+  if command -v notify-send >/dev/null 2>&1; then
+    notify-send "codex-gemma job $status" "$job_id" >/dev/null 2>&1 || true
+  fi
+}
+
+orchestrate_run() {
+  local job_id="$1"
+  local task="$2"
+  local max_refine="$3"
+  local result_file
+  result_file="$(job_result_file "$job_id")"
+
+  append_trace "ORCH[$job_id] STEP" "PLAN"
+  local plan_prompt
+  plan_prompt=$'You are a worker model. Create a concise implementation plan for this task.\n\nTask:\n'"$task"$'\n\nOutput: 3-7 bullet points.'
+  local plan
+  plan="$(ask_cmd "$plan_prompt")"
+
+  append_trace "ORCH[$job_id] STEP" "IMPLEMENT"
+  local impl_prompt
+  impl_prompt=$'Implement the task below.\n\nTask:\n'"$task"$'\n\nOutput the implementation directly.'
+  local output
+  output="$(ask_cmd "$impl_prompt")"
+
+  local refine=0
+  while (( refine < max_refine )); do
+    append_trace "ORCH[$job_id] STEP" "SELF-CHECK $((refine+1))"
+    local check_prompt
+    check_prompt=$'Evaluate whether this output satisfies the task. Respond ONLY PASS or FAIL.\n\nTask:\n'"$task"$'\n\nOutput:\n'"$output"
+    local verdict
+    verdict="$(ask_cmd "$check_prompt" | tr -d '\r' | head -n 1)"
+    if [[ "$verdict" == "PASS" ]]; then
+      break
+    fi
+    append_trace "ORCH[$job_id] STEP" "REFINE $((refine+1))"
+    local refine_prompt
+    refine_prompt=$'Revise the output to fully satisfy the task.\n\nTask:\n'"$task"$'\n\nCurrent output:\n'"$output"$'\n\nReturn improved output only.'
+    output="$(ask_cmd "$refine_prompt")"
+    refine=$((refine + 1))
+  done
+
+  printf '%s\n' "$output" > "$result_file"
+}
+
+orchestrate_background() {
+  local job_id="$1"
+  local task="$2"
+  local max_refine="$3"
+  local log_file
+  log_file="$(job_log_file "$job_id")"
+  local rc=0
+  set +e
+  {
+    echo "job_id=$job_id"
+    echo "started_at=$(date -Is)"
+    orchestrate_run "$job_id" "$task" "$max_refine"
+    echo "finished_at=$(date -Is)"
+  } >"$log_file" 2>&1
+  rc=$?
+  set -e
+  if [[ "$rc" -eq 0 ]]; then
+    job_set_status "$job_id" "done"
+    append_trace "ORCH[$job_id] DONE" "result_file=$(job_result_file "$job_id")"
+    notify_completion "$job_id" "done"
+    return 0
+  fi
+  job_set_status "$job_id" "failed"
+  append_trace "ORCH[$job_id] FAILED" "log_file=$log_file rc=$rc"
+  notify_completion "$job_id" "failed"
+  return 1
+}
+
+orchestrate_cmd() {
+  local task=""
+  local max_refine=1
+  local async=0
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --max-refine)
+        shift
+        max_refine="${1:-1}"
+        ;;
+      --async)
+        async=1
+        ;;
+      *)
+        if [[ -z "$task" ]]; then
+          task="$1"
+        else
+          task="$task $1"
+        fi
+        ;;
+    esac
+    shift || true
+  done
+  if [[ -z "$task" ]]; then
+    echo "Usage: codex-gemma orchestrate \"task\" [--max-refine N] [--async]"
     exit 1
   fi
+  if ! [[ "$max_refine" =~ ^[0-9]+$ ]]; then
+    echo "max-refine must be a non-negative integer."
+    exit 1
+  fi
+
+  local job_id meta
+  job_id="job-$(date +%Y%m%d-%H%M%S)-$RANDOM"
+  meta="$(job_meta_file "$job_id")"
+  {
+    echo "job_id=$job_id"
+    echo "status=running"
+    echo "created_at=$(date -Is)"
+    echo "max_refine=$max_refine"
+    echo "task=$(printf '%q' "$task")"
+  } > "$meta"
+
+  append_trace "ORCH[$job_id] START" "$task"
+
+  if [[ "$async" -eq 1 ]]; then
+    local task_b64 unit
+    task_b64="$(python3 - "$task" <<'PY'
+import base64,sys
+print(base64.b64encode(sys.argv[1].encode("utf-8")).decode("ascii"))
+PY
+)"
+    unit="codex-gemma-job-${job_id}.service"
+    if ! systemd-run --user --unit "$unit" --collect \
+      "$0" _run-job "$job_id" "$max_refine" "$task_b64" >/dev/null; then
+      echo "Failed to start async job via systemd-run."
+      exit 1
+    fi
+    echo "unit=$unit" >> "$meta"
+    echo "job_id=$job_id"
+    echo "unit=$unit"
+    echo "status=running"
+    echo "log=$(job_log_file "$job_id")"
+    echo "follow: codex-gemma follow"
+    echo "status-check: codex-gemma status-job $job_id"
+    return 0
+  fi
+
+  if orchestrate_background "$job_id" "$task" "$max_refine"; then
+    echo "job_id=$job_id"
+    echo "status=done"
+    echo "result=$(job_result_file "$job_id")"
+  else
+    echo "job_id=$job_id"
+    echo "status=failed"
+    echo "log=$(job_log_file "$job_id")"
+    return 1
+  fi
+}
+
+jobs_cmd() {
+  local meta id status created
+  shopt -s nullglob
+  for meta in "$CG_JOBS_DIR"/*.meta; do
+    id="$(basename "$meta" .meta)"
+    status="$(sed -n 's/^status=//p' "$meta" | tail -n1)"
+    created="$(sed -n 's/^created_at=//p' "$meta" | tail -n1)"
+    echo "$id status=${status:-unknown} created_at=${created:-unknown}"
+  done
+  shopt -u nullglob
+}
+
+status_job_cmd() {
+  local job_id="${1:-}"
+  if [[ -z "$job_id" ]]; then
+    echo "Usage: codex-gemma status-job <job_id>"
+    exit 1
+  fi
+  local meta
+  meta="$(job_meta_file "$job_id")"
+  if [[ ! -f "$meta" ]]; then
+    echo "Job not found: $job_id"
+    exit 1
+  fi
+  cat "$meta"
+  local result log
+  result="$(job_result_file "$job_id")"
+  log="$(job_log_file "$job_id")"
+  [[ -f "$result" ]] && echo "result_file=$result"
+  [[ -f "$log" ]] && echo "log_file=$log"
+}
+
+wait_cmd() {
+  local job_id="${1:-}"
+  if [[ -z "$job_id" ]]; then
+    echo "Usage: codex-gemma wait <job_id>"
+    exit 1
+  fi
+  local meta status
+  meta="$(job_meta_file "$job_id")"
+  if [[ ! -f "$meta" ]]; then
+    echo "Job not found: $job_id"
+    exit 1
+  fi
+  while true; do
+    status="$(sed -n 's/^status=//p' "$meta" | tail -n1)"
+    if [[ "$status" == "done" || "$status" == "failed" ]]; then
+      echo "job_id=$job_id status=$status"
+      status_job_cmd "$job_id"
+      [[ "$status" == "done" ]] && return 0 || return 1
+    fi
+    sleep 2
+  done
+}
+
+run_job_cmd() {
+  local job_id="${1:-}"
+  local max_refine="${2:-1}"
+  local task_b64="${3:-}"
+  if [[ -z "$job_id" || -z "$task_b64" ]]; then
+    echo "Usage: codex-gemma _run-job <job_id> <max_refine> <task_b64>"
+    exit 1
+  fi
+  local task
+  task="$(python3 - "$task_b64" <<'PY'
+import base64,sys
+print(base64.b64decode(sys.argv[1]).decode("utf-8"))
+PY
+)"
+  orchestrate_background "$job_id" "$task" "$max_refine"
+}
+
+watch_cmd() {
+  local prompt
+  prompt="$(read_prompt_arg "${1:-}" "${2:-}")" || exit 1
 
   local tmp_log
   tmp_log="$(mktemp)"
@@ -184,6 +432,23 @@ main() {
     ask)
       shift || true
       ask_cmd "$@"
+      ;;
+    orchestrate)
+      shift || true
+      orchestrate_cmd "$@"
+      ;;
+    jobs) jobs_cmd ;;
+    status-job)
+      shift || true
+      status_job_cmd "${1:-}"
+      ;;
+    _run-job)
+      shift || true
+      run_job_cmd "${1:-}" "${2:-}" "${3:-}"
+      ;;
+    wait)
+      shift || true
+      wait_cmd "${1:-}"
       ;;
     follow) follow_cmd ;;
     watch)

--- a/scripts/codex-gemma
+++ b/scripts/codex-gemma
@@ -1,6 +1,17 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+if [[ "${CODEX_GEMMA_ALLOW_HISTORICAL:-0}" != "1" ]]; then
+  cat <<'EOF'
+Retired: codex-gemma is no longer part of the active Open Terminal operational path.
+Use packet-mediated local-worker delegation instead.
+
+Set CODEX_GEMMA_ALLOW_HISTORICAL=1 only if you need this historical wrapper for
+a benchmark or migration audit.
+EOF
+  exit 1
+fi
+
 GEMMA_ENDPOINT="${GEMMA_ENDPOINT:-http://127.0.0.1:8000/v1}"
 GEMMA_UNIT="${GEMMA_UNIT:-z490-gemma-llama.service}"
 QWEN_ENDPOINT="${QWEN_ENDPOINT:-http://127.0.0.1:8091/v1}"

--- a/scripts/codex-gemma
+++ b/scripts/codex-gemma
@@ -3,6 +3,10 @@ set -euo pipefail
 
 GEMMA_ENDPOINT="${GEMMA_ENDPOINT:-http://127.0.0.1:8000/v1}"
 GEMMA_UNIT="${GEMMA_UNIT:-z490-gemma-llama.service}"
+QWEN_ENDPOINT="${QWEN_ENDPOINT:-http://127.0.0.1:8091/v1}"
+CODEX_GEMMA_POLICY_MODE="${CODEX_GEMMA_POLICY_MODE:-strict}"
+CODEX_GEMMA_MAX_RETRIES="${CODEX_GEMMA_MAX_RETRIES:-2}"
+CODEX_GEMMA_FALLBACK_ON_FAIL="${CODEX_GEMMA_FALLBACK_ON_FAIL:-1}"
 CG_STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/open-terminal"
 CG_TRACE_FILE="${CG_STATE_DIR}/codex-gemma-trace.log"
 CG_JOBS_DIR="${CG_STATE_DIR}/codex-gemma-jobs"
@@ -16,7 +20,7 @@ codex-gemma - bridge for Codex CLI to message/control local Gemma backend
 Usage:
   codex-gemma status
   codex-gemma models
-  codex-gemma ask "your prompt"
+  codex-gemma ask [--policy strict|off] [--retries N] [--fallback none|qwen2] "your prompt"
   codex-gemma ask --file /path/to/prompt.txt
   codex-gemma orchestrate "task" [--max-refine N] [--async]
   codex-gemma jobs
@@ -31,8 +35,12 @@ Usage:
 
 Env overrides:
   GEMMA_ENDPOINT (default: http://127.0.0.1:8000/v1)
+  QWEN_ENDPOINT  (default: http://127.0.0.1:8091/v1)
   GEMMA_UNIT     (default: z490-gemma-llama.service)
   CODEX_GEMMA_NOTIFY_CMD (optional completion hook; receives "<job_id> <status>")
+  CODEX_GEMMA_POLICY_MODE (strict|off, default: strict)
+  CODEX_GEMMA_MAX_RETRIES (default: 2)
+  CODEX_GEMMA_FALLBACK_ON_FAIL (0|1, default: 1)
 EOF
 }
 
@@ -57,30 +65,9 @@ models_cmd() {
   echo
 }
 
-read_prompt_arg() {
-  local prompt=""
-  if [[ "${1:-}" == "--file" ]]; then
-    if [[ -z "${2:-}" || ! -f "$2" ]]; then
-      echo "Missing prompt file." >&2
-      return 1
-    fi
-    prompt="$(cat "$2")"
-  else
-    prompt="${1:-}"
-  fi
-  if [[ -z "$prompt" ]]; then
-    echo "Prompt is empty." >&2
-    return 1
-  fi
-  printf '%s\n' "$prompt"
-}
-
-ask_cmd() {
-  local prompt
-  prompt="$(read_prompt_arg "${1:-}" "${2:-}")" || exit 1
-
-  local model
-  model="$(curl -fsS "${GEMMA_ENDPOINT%/}/models" | python3 -c '
+resolve_model_id_for_endpoint() {
+  local endpoint="$1"
+  curl -fsS "${endpoint%/}/models" | python3 -c '
 import json,sys
 try:
     d=json.load(sys.stdin)
@@ -88,10 +75,14 @@ try:
     print(arr[0].get("id","default") if arr else "default")
 except Exception:
     print("default")
-')"
+'
+}
 
-  local assistant
-  assistant="$(python3 - "$GEMMA_ENDPOINT" "$model" "$prompt" <<'PY'
+chat_once() {
+  local endpoint="$1"
+  local model="$2"
+  local prompt="$3"
+  python3 - "$endpoint" "$model" "$prompt" <<'PY'
 import json,sys,urllib.request
 endpoint,model,prompt=sys.argv[1],sys.argv[2],sys.argv[3]
 url=endpoint.rstrip('/') + '/chat/completions'
@@ -112,10 +103,183 @@ if isinstance(msg,list):
   msg="\n".join([p for p in parts if p])
 print(msg if isinstance(msg,str) else str(msg))
 PY
-)"
-  append_trace "CODEX->GEMMA prompt" "$prompt"
-  append_trace "GEMMA->CODEX response" "$assistant"
-  printf '%s\n' "$assistant"
+}
+
+detect_task_class() {
+  local prompt="$1"
+  python3 - "$prompt" <<'PY'
+import sys
+p=sys.argv[1].lower()
+if "print exactly this string and nothing else:" in p:
+    print("exact_literal")
+elif "def group_anagrams(words: list[str]) -> list[list[str]]" in p:
+    print("group_anagrams_contract")
+elif "exactly one runnable python code block" in p:
+    print("exact_one_code_block")
+else:
+    print("general")
+PY
+}
+
+validate_response() {
+  local task_class="$1"
+  local prompt="$2"
+  local candidate="$3"
+  python3 - "$task_class" "$prompt" "$candidate" <<'PY'
+import re,sys
+task=sys.argv[1]
+prompt=sys.argv[2]
+cand=sys.argv[3]
+
+def fail(msg):
+    print(msg)
+    raise SystemExit(1)
+
+if task == "exact_one_code_block":
+    blocks = re.findall(r"```(?:python)?\n[\s\S]*?\n```", cand)
+    if len(blocks) != 1:
+        fail(f"expected exactly one fenced code block, found {len(blocks)}")
+    cleaned = re.sub(r"```(?:python)?\n[\s\S]*?\n```", "", cand).strip()
+    if cleaned:
+        fail("expected no text outside code block")
+elif task == "group_anagrams_contract":
+    blocks = re.findall(r"```(?:python)?\n([\s\S]*?)\n```", cand)
+    if len(blocks) != 1:
+        fail("expected exactly one fenced code block")
+    code = blocks[0]
+    if "def group_anagrams(words: list[str]) -> list[list[str]]" not in code:
+        fail("missing exact function signature")
+    if '"""' not in code and "'''" not in code:
+        fail("missing docstring")
+    assert_count = len(re.findall(r"^\s*assert\s+", code, flags=re.MULTILINE))
+    if assert_count != 5:
+        fail(f"expected exactly 5 assert tests, found {assert_count}")
+elif task == "exact_literal":
+    m = re.search(r"Print exactly this string and nothing else:\s*([A-Za-z0-9_\-]+)", prompt, flags=re.IGNORECASE)
+    if m:
+        target = m.group(1).strip()
+        if cand.strip() != target:
+            fail(f"expected exact literal {target!r}")
+print("ok")
+PY
+}
+
+build_repair_prompt() {
+  local original_prompt="$1"
+  local invalid_output="$2"
+  cat <<EOF
+You must repair a prior response that violated strict output constraints.
+
+Original user prompt:
+$original_prompt
+
+Invalid prior response:
+$invalid_output
+
+Return corrected output only. No commentary.
+EOF
+}
+
+read_prompt_arg() {
+  local prompt=""
+  if [[ "${1:-}" == "--file" ]]; then
+    if [[ -z "${2:-}" || ! -f "$2" ]]; then
+      echo "Missing prompt file." >&2
+      return 1
+    fi
+    prompt="$(cat "$2")"
+  else
+    prompt="${1:-}"
+  fi
+  if [[ -z "$prompt" ]]; then
+    echo "Prompt is empty." >&2
+    return 1
+  fi
+  printf '%s\n' "$prompt"
+}
+
+ask_cmd() {
+  local policy="$CODEX_GEMMA_POLICY_MODE"
+  local retries="$CODEX_GEMMA_MAX_RETRIES"
+  local fallback="qwen2"
+  local args=()
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --policy) shift; policy="${1:-strict}" ;;
+      --retries) shift; retries="${1:-2}" ;;
+      --fallback) shift; fallback="${1:-qwen2}" ;;
+      *) args+=("$1") ;;
+    esac
+    shift || true
+  done
+  if ! [[ "$retries" =~ ^[0-9]+$ ]]; then
+    echo "Invalid --retries value: $retries" >&2
+    return 1
+  fi
+
+  local prompt
+  prompt="$(read_prompt_arg "${args[0]:-}" "${args[1]:-}")" || exit 1
+  local endpoint="$GEMMA_ENDPOINT"
+  local model
+  model="$(resolve_model_id_for_endpoint "$endpoint")"
+  local task_class
+  task_class="$(detect_task_class "$prompt")"
+  local attempt=0
+  local current_prompt="$prompt"
+  local assistant=""
+  local validation_msg=""
+
+  append_trace "POLICY" "mode=$policy retries=$retries task_class=$task_class endpoint=$endpoint"
+  while (( attempt <= retries )); do
+    assistant="$(chat_once "$endpoint" "$model" "$current_prompt")" || {
+      append_trace "ASK_ERROR" "attempt=$attempt endpoint=$endpoint"
+      break
+    }
+    if [[ "$policy" != "strict" || "$task_class" == "general" ]]; then
+      append_trace "CODEX->GEMMA prompt" "$current_prompt"
+      append_trace "GEMMA->CODEX response" "$assistant"
+      printf '%s\n' "$assistant"
+      return 0
+    fi
+    if validation_msg="$(validate_response "$task_class" "$prompt" "$assistant" 2>&1)"; then
+      append_trace "CODEX->GEMMA prompt" "$current_prompt"
+      append_trace "GEMMA->CODEX response" "$assistant"
+      printf '%s\n' "$assistant"
+      return 0
+    fi
+    append_trace "VALIDATION_FAIL" "attempt=$attempt task_class=$task_class detail=$validation_msg"
+    current_prompt="$(build_repair_prompt "$prompt" "$assistant")"
+    attempt=$((attempt + 1))
+  done
+
+  if [[ "$policy" == "strict" && "$CODEX_GEMMA_FALLBACK_ON_FAIL" == "1" && "$fallback" == "qwen2" ]]; then
+    local fb_endpoint="$QWEN_ENDPOINT"
+    local fb_model=""
+    fb_model="$(resolve_model_id_for_endpoint "$fb_endpoint" 2>/dev/null || true)"
+    if [[ -n "$fb_model" ]]; then
+      append_trace "FALLBACK" "reason=validation_or_request_failure endpoint=$fb_endpoint model=$fb_model"
+      current_prompt="$prompt"
+      attempt=0
+      while (( attempt <= retries )); do
+        assistant="$(chat_once "$fb_endpoint" "$fb_model" "$current_prompt")" || break
+        if [[ "$task_class" == "general" ]] || validation_msg="$(validate_response "$task_class" "$prompt" "$assistant" 2>&1)"; then
+          append_trace "CODEX->QWEN prompt" "$current_prompt"
+          append_trace "QWEN->CODEX response" "$assistant"
+          printf '%s\n' "$assistant"
+          return 0
+        fi
+        append_trace "FALLBACK_VALIDATION_FAIL" "attempt=$attempt task_class=$task_class detail=$validation_msg"
+        current_prompt="$(build_repair_prompt "$prompt" "$assistant")"
+        attempt=$((attempt + 1))
+      done
+    fi
+  fi
+
+  echo "Request failed strict policy after retries."
+  if [[ -n "$validation_msg" ]]; then
+    echo "Last validation error: $validation_msg"
+  fi
+  return 1
 }
 
 start_cmd() { systemctl --user start "$GEMMA_UNIT"; }

--- a/scripts/codex-gemma
+++ b/scripts/codex-gemma
@@ -3,6 +3,10 @@ set -euo pipefail
 
 GEMMA_ENDPOINT="${GEMMA_ENDPOINT:-http://127.0.0.1:8000/v1}"
 GEMMA_UNIT="${GEMMA_UNIT:-z490-gemma-llama.service}"
+CG_STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/open-terminal"
+CG_TRACE_FILE="${CG_STATE_DIR}/codex-gemma-trace.log"
+mkdir -p "$CG_STATE_DIR"
+touch "$CG_TRACE_FILE"
 
 usage() {
   cat <<'EOF'
@@ -13,6 +17,7 @@ Usage:
   codex-gemma models
   codex-gemma ask "your prompt"
   codex-gemma ask --file /path/to/prompt.txt
+  codex-gemma follow
   codex-gemma watch "your prompt"
   codex-gemma watch --file /path/to/prompt.txt
   codex-gemma start|stop|restart
@@ -74,7 +79,8 @@ except Exception:
     print("default")
 ')"
 
-  python3 - "$GEMMA_ENDPOINT" "$model" "$prompt" <<'PY'
+  local assistant
+  assistant="$(python3 - "$GEMMA_ENDPOINT" "$model" "$prompt" <<'PY'
 import json,sys,urllib.request
 endpoint,model,prompt=sys.argv[1],sys.argv[2],sys.argv[3]
 url=endpoint.rstrip('/') + '/chat/completions'
@@ -95,12 +101,26 @@ if isinstance(msg,list):
   msg="\n".join([p for p in parts if p])
 print(msg if isinstance(msg,str) else str(msg))
 PY
+)"
+  append_trace "CODEX->GEMMA prompt" "$prompt"
+  append_trace "GEMMA->CODEX response" "$assistant"
+  printf '%s\n' "$assistant"
 }
 
 start_cmd() { systemctl --user start "$GEMMA_UNIT"; }
 stop_cmd() { systemctl --user stop "$GEMMA_UNIT"; }
 restart_cmd() { systemctl --user restart "$GEMMA_UNIT"; }
 logs_cmd() { journalctl --user -u "$GEMMA_UNIT" -n "${1:-120}" --no-pager; }
+
+append_trace() {
+  local role="$1"
+  local text="$2"
+  {
+    printf '[%s] %s\n' "$(date -Is)" "$role"
+    printf '%s\n' "$text"
+    printf '\n'
+  } >> "$CG_TRACE_FILE"
+}
 
 watch_cmd() {
   local prompt=""
@@ -151,6 +171,12 @@ watch_cmd() {
   rm -f "$tmp_log"
 }
 
+follow_cmd() {
+  echo "Following Codex<->Gemma transcript: $CG_TRACE_FILE"
+  echo "Press Ctrl+C to stop."
+  tail -n 80 -f "$CG_TRACE_FILE"
+}
+
 main() {
   case "${1:-help}" in
     status) status_cmd ;;
@@ -159,6 +185,7 @@ main() {
       shift || true
       ask_cmd "$@"
       ;;
+    follow) follow_cmd ;;
     watch)
       shift || true
       watch_cmd "$@"

--- a/scripts/codex-gemma
+++ b/scripts/codex-gemma
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+GEMMA_ENDPOINT="${GEMMA_ENDPOINT:-http://127.0.0.1:8000/v1}"
+GEMMA_UNIT="${GEMMA_UNIT:-z490-gemma-llama.service}"
+
+usage() {
+  cat <<'EOF'
+codex-gemma - bridge for Codex CLI to message/control local Gemma backend
+
+Usage:
+  codex-gemma status
+  codex-gemma models
+  codex-gemma ask "your prompt"
+  codex-gemma ask --file /path/to/prompt.txt
+  codex-gemma start|stop|restart
+  codex-gemma logs [N]
+  codex-gemma endpoint
+
+Env overrides:
+  GEMMA_ENDPOINT (default: http://127.0.0.1:8000/v1)
+  GEMMA_UNIT     (default: z490-gemma-llama.service)
+EOF
+}
+
+endpoint() {
+  echo "$GEMMA_ENDPOINT"
+}
+
+status_cmd() {
+  echo "systemd:"
+  systemctl --user --no-pager status "$GEMMA_UNIT" || true
+  echo
+  echo "endpoint:"
+  if curl -fsS "${GEMMA_ENDPOINT%/}/models" >/dev/null 2>&1; then
+    echo "reachable: yes"
+  else
+    echo "reachable: no"
+  fi
+}
+
+models_cmd() {
+  curl -fsS "${GEMMA_ENDPOINT%/}/models"
+  echo
+}
+
+ask_cmd() {
+  local prompt=""
+  if [[ "${1:-}" == "--file" ]]; then
+    if [[ -z "${2:-}" || ! -f "$2" ]]; then
+      echo "Missing prompt file."
+      exit 1
+    fi
+    prompt="$(cat "$2")"
+  else
+    prompt="${1:-}"
+  fi
+
+  if [[ -z "$prompt" ]]; then
+    echo "Prompt is empty."
+    exit 1
+  fi
+
+  local model
+  model="$(curl -fsS "${GEMMA_ENDPOINT%/}/models" | python3 - <<'PY'
+import json,sys
+try:
+  d=json.load(sys.stdin)
+  arr=d.get("data") or []
+  print(arr[0].get("id","default") if arr else "default")
+except Exception:
+  print("default")
+PY
+)"
+
+  python3 - "$GEMMA_ENDPOINT" "$model" "$prompt" <<'PY'
+import json,sys,urllib.request
+endpoint,model,prompt=sys.argv[1],sys.argv[2],sys.argv[3]
+url=endpoint.rstrip('/') + '/chat/completions'
+payload={
+  "model": model,
+  "messages":[{"role":"user","content":prompt}],
+  "temperature":0.2
+}
+req=urllib.request.Request(url,data=json.dumps(payload).encode("utf-8"),headers={"Content-Type":"application/json","Authorization":"Bearer dummy"})
+with urllib.request.urlopen(req,timeout=180) as r:
+  data=json.loads(r.read())
+msg=((data.get("choices") or [{}])[0].get("message") or {}).get("content","")
+if isinstance(msg,list):
+  parts=[]
+  for item in msg:
+    if isinstance(item,dict) and item.get("type")=="text":
+      parts.append(str(item.get("text","")))
+  msg="\n".join([p for p in parts if p])
+print(msg if isinstance(msg,str) else str(msg))
+PY
+}
+
+start_cmd() { systemctl --user start "$GEMMA_UNIT"; }
+stop_cmd() { systemctl --user stop "$GEMMA_UNIT"; }
+restart_cmd() { systemctl --user restart "$GEMMA_UNIT"; }
+logs_cmd() { journalctl --user -u "$GEMMA_UNIT" -n "${1:-120}" --no-pager; }
+
+main() {
+  case "${1:-help}" in
+    status) status_cmd ;;
+    models) models_cmd ;;
+    ask)
+      shift || true
+      ask_cmd "$@"
+      ;;
+    start) start_cmd ;;
+    stop) stop_cmd ;;
+    restart) restart_cmd ;;
+    logs)
+      shift || true
+      logs_cmd "${1:-120}"
+      ;;
+    endpoint) endpoint ;;
+    help|-h|--help) usage ;;
+    *)
+      echo "Unknown subcommand: ${1:-}"
+      usage
+      exit 1
+      ;;
+  esac
+}
+
+main "$@"

--- a/scripts/codex-gemma
+++ b/scripts/codex-gemma
@@ -62,16 +62,15 @@ ask_cmd() {
   fi
 
   local model
-  model="$(curl -fsS "${GEMMA_ENDPOINT%/}/models" | python3 - <<'PY'
+  model="$(curl -fsS "${GEMMA_ENDPOINT%/}/models" | python3 -c '
 import json,sys
 try:
-  d=json.load(sys.stdin)
-  arr=d.get("data") or []
-  print(arr[0].get("id","default") if arr else "default")
+    d=json.load(sys.stdin)
+    arr=d.get("data") or []
+    print(arr[0].get("id","default") if arr else "default")
 except Exception:
-  print("default")
-PY
-)"
+    print("default")
+')"
 
   python3 - "$GEMMA_ENDPOINT" "$model" "$prompt" <<'PY'
 import json,sys,urllib.request

--- a/scripts/codex-gemma
+++ b/scripts/codex-gemma
@@ -22,6 +22,8 @@ Usage:
   codex-gemma models
   codex-gemma ask [--policy strict|off] [--retries N] [--fallback none|qwen2] [--single-model-lock on|off] "your prompt"
   codex-gemma ask --file /path/to/prompt.txt
+  codex-gemma benchmark [--retries N] [--target gemma|qwen2] "your prompt"
+  codex-gemma benchmark --file /path/to/prompt.txt
   codex-gemma orchestrate "task" [--max-refine N] [--async]
   codex-gemma jobs
   codex-gemma status-job <job_id>
@@ -294,6 +296,36 @@ ask_cmd() {
     echo "Last validation error: $validation_msg"
   fi
   return 1
+}
+
+benchmark_cmd() {
+  local retries="$CODEX_GEMMA_MAX_RETRIES"
+  local target="qwen2"
+  local args=()
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --retries) shift; retries="${1:-2}" ;;
+      --target) shift; target="${1:-qwen2}" ;;
+      *) args+=("$1") ;;
+    esac
+    shift || true
+  done
+  if ! [[ "$retries" =~ ^[0-9]+$ ]]; then
+    echo "Invalid --retries value: $retries" >&2
+    return 1
+  fi
+  if [[ "$target" != "gemma" && "$target" != "qwen2" ]]; then
+    echo "Invalid --target value: $target (expected gemma|qwen2)" >&2
+    return 1
+  fi
+
+  append_trace "BENCHMARK_MODE" "target=$target retries=$retries single_model_lock=off fallback=$([[ "$target" == "qwen2" ]] && echo qwen2 || echo none)"
+
+  if [[ "$target" == "qwen2" ]]; then
+    ask_cmd --policy strict --retries "$retries" --fallback qwen2 --single-model-lock off "${args[@]}"
+  else
+    ask_cmd --policy strict --retries "$retries" --fallback none --single-model-lock off "${args[@]}"
+  fi
 }
 
 start_cmd() { systemctl --user start "$GEMMA_UNIT"; }
@@ -610,6 +642,10 @@ main() {
     ask)
       shift || true
       ask_cmd "$@"
+      ;;
+    benchmark)
+      shift || true
+      benchmark_cmd "$@"
       ;;
     orchestrate)
       shift || true

--- a/scripts/guarded-run.sh
+++ b/scripts/guarded-run.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: $0 \"<command>\" [--force]"
+  exit 1
+fi
+
+CMD="$1"
+FORCE="${2:-}"
+
+if [[ "$PWD" != /home/trotsky/Projects* ]]; then
+  echo "Refusing to run outside /home/trotsky/Projects"
+  exit 1
+fi
+
+if [[ "$CMD" =~ (^|[[:space:]])(rm[[:space:]]+-rf|mkfs|dd[[:space:]]+if=|shutdown|reboot|poweroff)($|[[:space:]]) ]] && [[ "$FORCE" != "--force" ]]; then
+  echo "Blocked risky command. Re-run with --force if explicitly approved."
+  exit 1
+fi
+
+if [[ "$CMD" =~ /etc|/usr|/var ]] && [[ "$FORCE" != "--force" ]]; then
+  echo "Blocked system-path edit/access command. Re-run with --force if explicitly approved."
+  exit 1
+fi
+
+echo "[$(date -Is)] $CMD" >> "${XDG_STATE_HOME:-$HOME/.local/state}/open-terminal/guarded-run.log"
+bash -lc "$CMD"

--- a/scripts/install-codex-gemma-cli.sh
+++ b/scripts/install-codex-gemma-cli.sh
@@ -6,9 +6,23 @@ SRC="$ROOT_DIR/scripts/codex-gemma"
 DST_DIR="$HOME/.local/bin"
 DST="$DST_DIR/codex-gemma"
 
+if [[ "${CODEX_GEMMA_ALLOW_HISTORICAL:-0}" != "1" ]]; then
+  cat <<'EOF'
+Retired: codex-gemma is no longer installed as an active Open Terminal operational path.
+Use packet-mediated local-worker delegation instead.
+
+If you need the historical wrapper for a benchmark or migration audit, rerun with:
+  CODEX_GEMMA_ALLOW_HISTORICAL=1 scripts/install-codex-gemma-cli.sh
+
+If you later want to remove the historical wrapper entirely:
+  rm -f "$HOME/.local/bin/codex-gemma"
+EOF
+  exit 1
+fi
+
 mkdir -p "$DST_DIR"
 chmod +x "$SRC"
 ln -sfn "$SRC" "$DST"
 
 echo "Installed: $DST"
-echo "Use: codex-gemma status | codex-gemma ask \"hello\""
+echo "Historical use only: CODEX_GEMMA_ALLOW_HISTORICAL=1 codex-gemma <args>"

--- a/scripts/install-codex-gemma-cli.sh
+++ b/scripts/install-codex-gemma-cli.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SRC="$ROOT_DIR/scripts/codex-gemma"
+DST_DIR="$HOME/.local/bin"
+DST="$DST_DIR/codex-gemma"
+
+mkdir -p "$DST_DIR"
+chmod +x "$SRC"
+ln -sfn "$SRC" "$DST"
+
+echo "Installed: $DST"
+echo "Use: codex-gemma status | codex-gemma ask \"hello\""

--- a/scripts/install-open-terminal-cli.sh
+++ b/scripts/install-open-terminal-cli.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SRC="$ROOT_DIR/scripts/open-terminal"
+DST_DIR="$HOME/.local/bin"
+DST="$DST_DIR/open-terminal"
+
+mkdir -p "$DST_DIR"
+chmod +x "$SRC"
+ln -sfn "$SRC" "$DST"
+
+echo "Installed: $DST"
+echo "Run: open-terminal"

--- a/scripts/install-user-service.sh
+++ b/scripts/install-user-service.sh
@@ -4,12 +4,20 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 UNIT_SRC="$ROOT_DIR/systemd/open-terminal.service"
 UNIT_DST="$HOME/.config/systemd/user/open-terminal.service"
+VERIFY_SERVICE_SRC="$ROOT_DIR/systemd/open-terminal-verify.service"
+VERIFY_SERVICE_DST="$HOME/.config/systemd/user/open-terminal-verify.service"
+VERIFY_TIMER_SRC="$ROOT_DIR/systemd/open-terminal-verify.timer"
+VERIFY_TIMER_DST="$HOME/.config/systemd/user/open-terminal-verify.timer"
 
 mkdir -p "$HOME/.config/systemd/user"
 cp "$UNIT_SRC" "$UNIT_DST"
+cp "$VERIFY_SERVICE_SRC" "$VERIFY_SERVICE_DST"
+cp "$VERIFY_TIMER_SRC" "$VERIFY_TIMER_DST"
 
 systemctl --user daemon-reload
 systemctl --user enable open-terminal.service
+systemctl --user enable open-terminal-verify.timer
 
 echo "Installed user service: $UNIT_DST"
+echo "Installed verify units: $VERIFY_SERVICE_DST, $VERIFY_TIMER_DST"
 echo "Start with: systemctl --user start open-terminal"

--- a/scripts/install-user-service.sh
+++ b/scripts/install-user-service.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+UNIT_SRC="$ROOT_DIR/systemd/open-terminal.service"
+UNIT_DST="$HOME/.config/systemd/user/open-terminal.service"
+
+mkdir -p "$HOME/.config/systemd/user"
+cp "$UNIT_SRC" "$UNIT_DST"
+
+systemctl --user daemon-reload
+systemctl --user enable open-terminal.service
+
+echo "Installed user service: $UNIT_DST"
+echo "Start with: systemctl --user start open-terminal"

--- a/scripts/logs.sh
+++ b/scripts/logs.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+journalctl --user -u open-terminal -n "${1:-200}" --no-pager

--- a/scripts/midnight-dust-watcher
+++ b/scripts/midnight-dust-watcher
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+midnight-dust-watcher
+
+Polls dust readiness and triggers fee-bearing deploy when spendable DUST appears.
+
+Usage:
+  scripts/midnight-dust-watcher --repo PATH [options]
+
+Options:
+  --repo PATH               Midnight gateway repo path (required)
+  --interval-sec N          Poll interval seconds (default: 120)
+  --max-minutes N           Total watch window minutes (default: 240)
+  --timeout-ms N            Sync probe timeout ms (default: 120000)
+  --deploy-timeout-ms N     Deploy probe timeout ms (default: 180000)
+  --state-dir PATH          Output dir (default: ~/.local/state/open-terminal/midnight-dust-watch)
+  --env-file PATH           Optional env file to source
+  -h, --help                Show help
+EOF
+}
+
+REPO=""
+INTERVAL_SEC=120
+MAX_MINUTES=240
+SYNC_TIMEOUT_MS=120000
+DEPLOY_TIMEOUT_MS=180000
+STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/open-terminal/midnight-dust-watch"
+ENV_FILE=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo) REPO="${2:-}"; shift 2 ;;
+    --interval-sec) INTERVAL_SEC="${2:-}"; shift 2 ;;
+    --max-minutes) MAX_MINUTES="${2:-}"; shift 2 ;;
+    --timeout-ms) SYNC_TIMEOUT_MS="${2:-}"; shift 2 ;;
+    --deploy-timeout-ms) DEPLOY_TIMEOUT_MS="${2:-}"; shift 2 ;;
+    --state-dir) STATE_DIR="${2:-}"; shift 2 ;;
+    --env-file) ENV_FILE="${2:-}"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown argument: $1" >&2; usage; exit 2 ;;
+  esac
+done
+
+if [[ -z "$REPO" ]]; then
+  echo "--repo is required" >&2
+  usage
+  exit 2
+fi
+if [[ ! -d "$REPO" ]]; then
+  echo "repo not found: $REPO" >&2
+  exit 2
+fi
+if [[ ! -f "$REPO/package.json" ]]; then
+  echo "package.json not found in repo: $REPO" >&2
+  exit 2
+fi
+if [[ -n "$ENV_FILE" ]]; then
+  if [[ ! -f "$ENV_FILE" ]]; then
+    echo "env file not found: $ENV_FILE" >&2
+    exit 2
+  fi
+  # shellcheck disable=SC1090
+  set -a; source "$ENV_FILE"; set +a
+fi
+
+mkdir -p "$STATE_DIR"
+RUN_ID="$(date +%Y%m%d-%H%M%S)"
+LOG_JSONL="$STATE_DIR/watch-$RUN_ID.jsonl"
+RAW_DIR="$STATE_DIR/raw-$RUN_ID"
+mkdir -p "$RAW_DIR"
+
+export MIDNIGHT_WALLET_SDK_FEE_BLOCKS_MARGIN="${MIDNIGHT_WALLET_SDK_FEE_BLOCKS_MARGIN:-2}"
+export MIDNIGHT_WALLET_SDK_COMPONENT_SYNC_TIMEOUT_MS="$SYNC_TIMEOUT_MS"
+
+START_EPOCH="$(date +%s)"
+END_EPOCH="$((START_EPOCH + MAX_MINUTES * 60))"
+LOOP=0
+
+json_quote() {
+  python3 - <<'PY' "$1"
+import json,sys
+print(json.dumps(sys.argv[1]))
+PY
+}
+
+parse_sync_probe() {
+  python3 - <<'PY' "$1"
+import json,re,sys
+text=open(sys.argv[1],encoding='utf-8',errors='ignore').read()
+m=re.search(r'\{[\s\S]*\}\s*$', text)
+if not m:
+    print("0\t0\t\tparse_error")
+    sys.exit(0)
+blob=m.group(0)
+try:
+    d=json.loads(blob)
+except Exception:
+    print("0\t0\t\tparse_error")
+    sys.exit(0)
+available=d.get("availableCoinCount",0)
+pending=d.get("pendingCoinCount",0)
+balance=d.get("dustBalanceNow","")
+blocker=d.get("topBlocker","")
+print(f"{available}\t{pending}\t{balance}\t{blocker}")
+PY
+}
+
+parse_deploy_probe() {
+  python3 - <<'PY' "$1"
+import json,re,sys
+text=open(sys.argv[1],encoding='utf-8',errors='ignore').read()
+m=re.search(r'\{[\s\S]*\}\s*$', text)
+if not m:
+    print("unknown\tparse_error\t")
+    sys.exit(0)
+blob=m.group(0)
+try:
+    d=json.loads(blob)
+except Exception:
+    print("unknown\tparse_error\t")
+    sys.exit(0)
+state=d.get("deployState","unknown")
+blocker=d.get("topBlocker","")
+addr=(d.get("result") or {}).get("contractAddress","")
+print(f"{state}\t{blocker}\t{addr}")
+PY
+}
+
+cd "$REPO"
+
+while [[ "$(date +%s)" -lt "$END_EPOCH" ]]; do
+  LOOP=$((LOOP + 1))
+  TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  RAW_SYNC="$RAW_DIR/sync-$LOOP.log"
+
+  npm run -s probe:wallet-sdk-dust-sync-diagnostics >"$RAW_SYNC" 2>&1 || true
+  IFS=$'\t' read -r AVAILABLE PENDING BALANCE BLOCKER < <(parse_sync_probe "$RAW_SYNC")
+
+  printf '{"ts":"%s","loop":%s,"available":%s,"pending":%s,"balance":%s,"blocker":%s}\n' \
+    "$TS" "$LOOP" "${AVAILABLE:-0}" "${PENDING:-0}" "$(json_quote "${BALANCE:-}")" "$(json_quote "${BLOCKER:-}")" \
+    >> "$LOG_JSONL"
+
+  if [[ "${AVAILABLE:-0}" =~ ^[0-9]+$ ]] && [[ "${AVAILABLE:-0}" -gt 0 ]]; then
+    RAW_DEPLOY="$RAW_DIR/deploy-$LOOP.log"
+    npm run -s probe:wallet-sdk-fee-bearing-deploy -- --timeout-ms "$DEPLOY_TIMEOUT_MS" >"$RAW_DEPLOY" 2>&1 || true
+    IFS=$'\t' read -r DEPLOY_STATE DEPLOY_BLOCKER CONTRACT_ADDR < <(parse_deploy_probe "$RAW_DEPLOY")
+    TS2="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    printf '{"ts":"%s","loop":%s,"event":"deploy_attempt","deployState":%s,"topBlocker":%s,"contractAddress":%s,"rawPath":%s}\n' \
+      "$TS2" "$LOOP" "$(json_quote "$DEPLOY_STATE")" "$(json_quote "$DEPLOY_BLOCKER")" "$(json_quote "$CONTRACT_ADDR")" "$(json_quote "$RAW_DEPLOY")" \
+      >> "$LOG_JSONL"
+    if [[ "$DEPLOY_STATE" == "wallet-sdk-fee-bearing-deploy-succeeded" ]]; then
+      echo "SUCCESS log=$LOG_JSONL"
+      exit 0
+    fi
+    echo "DEPLOY_REVIEW_REQUIRED log=$LOG_JSONL"
+    exit 1
+  fi
+
+  sleep "$INTERVAL_SEC"
+done
+
+TS3="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+printf '{"ts":"%s","event":"timeout","maxMinutes":%s,"lastLoop":%s}\n' "$TS3" "$MAX_MINUTES" "$LOOP" >> "$LOG_JSONL"
+echo "TIMEOUT log=$LOG_JSONL"
+exit 2

--- a/scripts/midnight-probe-loop
+++ b/scripts/midnight-probe-loop
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+midnight-probe-loop - bounded BA-Midnight readiness loop
+
+Usage:
+  scripts/midnight-probe-loop --repo /path/to/midnight-gateway [options]
+
+Options:
+  --repo PATH           Midnight gateway repo path (required)
+  --cycles N            Number of probe cycles (default: 3)
+  --sleep-sec N         Sleep seconds between cycles (default: 15)
+  --timeout-ms N        Warm-state timeout ms (default: 90000)
+  --fee-timeout-ms N    Deploy probe timeout ms (default: 180000)
+  --env-file PATH       Optional env file to source before runs
+  --execute             Run deploy probe when ready (default: inspect only)
+  -h, --help            Show this help
+EOF
+}
+
+REPO=""
+CYCLES=3
+SLEEP_SEC=15
+TIMEOUT_MS=90000
+FEE_TIMEOUT_MS=180000
+ENV_FILE=""
+EXECUTE=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo) REPO="${2:-}"; shift 2 ;;
+    --cycles) CYCLES="${2:-}"; shift 2 ;;
+    --sleep-sec) SLEEP_SEC="${2:-}"; shift 2 ;;
+    --timeout-ms) TIMEOUT_MS="${2:-}"; shift 2 ;;
+    --fee-timeout-ms) FEE_TIMEOUT_MS="${2:-}"; shift 2 ;;
+    --env-file) ENV_FILE="${2:-}"; shift 2 ;;
+    --execute) EXECUTE=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown argument: $1" >&2; usage; exit 2 ;;
+  esac
+done
+
+if [[ -z "$REPO" ]]; then
+  echo "--repo is required" >&2
+  usage
+  exit 2
+fi
+if [[ ! -d "$REPO" ]]; then
+  echo "Repo path not found: $REPO" >&2
+  exit 2
+fi
+if [[ ! -f "$REPO/package.json" ]]; then
+  echo "package.json not found in: $REPO" >&2
+  exit 2
+fi
+
+if [[ -n "$ENV_FILE" ]]; then
+  if [[ ! -f "$ENV_FILE" ]]; then
+    echo "env file not found: $ENV_FILE" >&2
+    exit 2
+  fi
+  # shellcheck disable=SC1090
+  set -a; source "$ENV_FILE"; set +a
+fi
+
+STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/open-terminal/midnight-probe-loop"
+mkdir -p "$STATE_DIR"
+RUN_ID="$(date +%Y%m%d-%H%M%S)"
+LOG="$STATE_DIR/run-$RUN_ID.log"
+SUMMARY="$STATE_DIR/run-$RUN_ID.summary"
+
+echo "run_id=$RUN_ID" | tee -a "$LOG"
+echo "repo=$REPO" | tee -a "$LOG"
+echo "cycles=$CYCLES sleep_sec=$SLEEP_SEC timeout_ms=$TIMEOUT_MS fee_timeout_ms=$FEE_TIMEOUT_MS execute=$EXECUTE" | tee -a "$LOG"
+
+cd "$REPO"
+
+ready=0
+for ((i=1; i<=CYCLES; i++)); do
+  echo "" | tee -a "$LOG"
+  echo "=== cycle $i/$CYCLES ===" | tee -a "$LOG"
+
+  diag_out="$(npm run -s probe:wallet-sdk-dust-sync-diagnostics 2>&1 || true)"
+  echo "$diag_out" | tee -a "$LOG" >/dev/null
+  available_now="$(printf '%s\n' "$diag_out" | sed -n 's/.*availableCoinCount=\([0-9][0-9]*\).*/\1/p' | tail -n1)"
+  [[ -n "$available_now" ]] || available_now=0
+
+  reg_out="$(npm run -s probe:wallet-sdk-dust-registration 2>&1 || true)"
+  echo "$reg_out" | tee -a "$LOG" >/dev/null
+  already_registered="$(printf '%s\n' "$reg_out" | sed -n 's/.*alreadyRegisteredCount=\([0-9][0-9]*\).*/\1/p' | tail -n1)"
+  [[ -n "$already_registered" ]] || already_registered=0
+
+  warm_out="$(npm run -s probe:wallet-sdk-dust-warm-state -- --timeout-ms "$TIMEOUT_MS" 2>&1 || true)"
+  echo "$warm_out" | tee -a "$LOG" >/dev/null
+  available_end="$(printf '%s\n' "$warm_out" | sed -n 's/.*availableCoinCountEnd=\([0-9][0-9]*\).*/\1/p' | tail -n1)"
+  [[ -n "$available_end" ]] || available_end=0
+
+  printf 'cycle=%s available_now=%s available_end=%s already_registered=%s\n' "$i" "$available_now" "$available_end" "$already_registered" | tee -a "$SUMMARY"
+
+  if [[ "$available_end" -gt 0 ]]; then
+    ready=1
+    echo "readiness gate opened at cycle $i (availableCoinCountEnd=$available_end)" | tee -a "$LOG"
+    break
+  fi
+
+  if [[ "$i" -lt "$CYCLES" ]]; then
+    sleep "$SLEEP_SEC"
+  fi
+done
+
+if [[ "$ready" -eq 1 && "$EXECUTE" -eq 1 ]]; then
+  echo "" | tee -a "$LOG"
+  echo "=== deploy probe (execute mode) ===" | tee -a "$LOG"
+  deploy_out="$(npm run -s probe:wallet-sdk-fee-bearing-deploy -- --timeout-ms "$FEE_TIMEOUT_MS" 2>&1 || true)"
+  echo "$deploy_out" | tee -a "$LOG" >/dev/null
+  if printf '%s\n' "$deploy_out" | rg -q "TaggedTransactionQueue|runtime error"; then
+    echo "deploy_signal=runtime_error_branch" | tee -a "$SUMMARY"
+  elif printf '%s\n' "$deploy_out" | rg -q "Wallet.InsufficientFunds|could not balance dust"; then
+    echo "deploy_signal=insufficient_dust" | tee -a "$SUMMARY"
+  else
+    echo "deploy_signal=other" | tee -a "$SUMMARY"
+  fi
+else
+  echo "deploy_signal=skipped" | tee -a "$SUMMARY"
+fi
+
+echo ""
+echo "Summary: $SUMMARY"
+echo "Log: $LOG"

--- a/scripts/model_baseline_cases.json
+++ b/scripts/model_baseline_cases.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": "codeblock_only",
+    "check": "exact_one_code_block",
+    "prompt": "Return exactly one runnable Python code block and nothing else. Write a function add(a: int, b: int) -> int and one assert test."
+  },
+  {
+    "id": "group_anagrams_contract",
+    "check": "group_anagrams_contract",
+    "prompt": "Return exactly one runnable Python code block and nothing else.\n\nImplement:\n\ndef group_anagrams(words: list[str]) -> list[list[str]]\n\nRequirements:\n- Group anagrams together.\n- Preserve original word order within each group.\n- Preserve group order by first appearance.\n- Case-insensitive grouping; preserve original casing in output.\n- Skip tokens that are empty or contain non-alphabetic characters.\n- Include docstring and type hints.\n- Include exactly 5 assert tests:\n  1) basic anagrams\n  2) mixed casing\n  3) duplicates\n  4) invalid tokens\n  5) empty input"
+  },
+  {
+    "id": "exact_literal",
+    "check": "exact_literal",
+    "literal": "OK_7F3C",
+    "prompt": "Print exactly this string and nothing else:\nOK_7F3C"
+  }
+]

--- a/scripts/model_baseline_cases.json
+++ b/scripts/model_baseline_cases.json
@@ -5,7 +5,17 @@
     "prompt": "Return exactly one runnable Python code block and nothing else. Write a function add(a: int, b: int) -> int and one assert test."
   },
   {
+    "id": "codeblock_factorial",
+    "check": "exact_one_code_block",
+    "prompt": "Return exactly one runnable Python code block and nothing else. Write factorial(n: int) -> int with input validation and two assert tests."
+  },
+  {
     "id": "group_anagrams_contract",
+    "check": "group_anagrams_contract",
+    "prompt": "Return exactly one runnable Python code block and nothing else.\n\nImplement:\n\ndef group_anagrams(words: list[str]) -> list[list[str]]\n\nRequirements:\n- Group anagrams together.\n- Preserve original word order within each group.\n- Preserve group order by first appearance.\n- Case-insensitive grouping; preserve original casing in output.\n- Skip tokens that are empty or contain non-alphabetic characters.\n- Include docstring and type hints.\n- Include exactly 5 assert tests:\n  1) basic anagrams\n  2) mixed casing\n  3) duplicates\n  4) invalid tokens\n  5) empty input"
+  },
+  {
+    "id": "group_anagrams_contract_repeat",
     "check": "group_anagrams_contract",
     "prompt": "Return exactly one runnable Python code block and nothing else.\n\nImplement:\n\ndef group_anagrams(words: list[str]) -> list[list[str]]\n\nRequirements:\n- Group anagrams together.\n- Preserve original word order within each group.\n- Preserve group order by first appearance.\n- Case-insensitive grouping; preserve original casing in output.\n- Skip tokens that are empty or contain non-alphabetic characters.\n- Include docstring and type hints.\n- Include exactly 5 assert tests:\n  1) basic anagrams\n  2) mixed casing\n  3) duplicates\n  4) invalid tokens\n  5) empty input"
   },
@@ -14,5 +24,32 @@
     "check": "exact_literal",
     "literal": "OK_7F3C",
     "prompt": "Print exactly this string and nothing else:\nOK_7F3C"
+  },
+  {
+    "id": "exact_literal_alt",
+    "check": "exact_literal",
+    "literal": "PASS_TOKEN_91A",
+    "prompt": "Print exactly this string and nothing else:\nPASS_TOKEN_91A"
+  },
+  {
+    "id": "exact_literal_short",
+    "check": "exact_literal",
+    "literal": "A1",
+    "prompt": "Print exactly this string and nothing else:\nA1"
+  },
+  {
+    "id": "codeblock_sum_list",
+    "check": "exact_one_code_block",
+    "prompt": "Return exactly one runnable Python code block and nothing else. Implement sum_positive(nums: list[int]) -> int that ignores negatives and include one assert."
+  },
+  {
+    "id": "codeblock_reverse_words",
+    "check": "exact_one_code_block",
+    "prompt": "Return exactly one runnable Python code block and nothing else. Implement reverse_words(s: str) -> str and include one assert."
+  },
+  {
+    "id": "codeblock_palindrome",
+    "check": "exact_one_code_block",
+    "prompt": "Return exactly one runnable Python code block and nothing else. Implement is_palindrome(s: str) -> bool and include two asserts."
   }
 ]

--- a/scripts/model_baseline_suite.py
+++ b/scripts/model_baseline_suite.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import re
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib.error import URLError
+from urllib.request import Request, urlopen
+
+
+DEFAULT_ENDPOINTS = {
+    "gemma": "http://127.0.0.1:8000/v1",
+    "qwen2": "http://127.0.0.1:8091/v1",
+}
+
+
+@dataclass
+class CaseResult:
+    case_id: str
+    ok: bool
+    latency_ms: int
+    detail: str
+    output_preview: str
+
+
+def http_json(url: str, payload: dict[str, Any] | None = None, timeout: int = 90) -> dict[str, Any]:
+    headers = {"Content-Type": "application/json", "Authorization": "Bearer dummy"}
+    data = None if payload is None else json.dumps(payload).encode("utf-8")
+    req = Request(url, data=data, headers=headers)
+    with urlopen(req, timeout=timeout) as resp:
+        raw = resp.read()
+    return json.loads(raw)
+
+
+def resolve_model_id(endpoint: str) -> str:
+    data = http_json(endpoint.rstrip("/") + "/models", None, timeout=8)
+    items = data.get("data") or []
+    if items and isinstance(items, list) and isinstance(items[0], dict):
+        return str(items[0].get("id") or "default")
+    return "default"
+
+
+def extract_text(resp: dict[str, Any]) -> str:
+    msg = ((resp.get("choices") or [{}])[0].get("message") or {}).get("content", "")
+    if isinstance(msg, list):
+        parts = []
+        for item in msg:
+            if isinstance(item, dict) and item.get("type") == "text":
+                parts.append(str(item.get("text", "")))
+        return "\n".join([p for p in parts if p]).strip()
+    return str(msg).strip()
+
+
+def check_exact_one_code_block(text: str) -> tuple[bool, str]:
+    blocks = re.findall(r"```(?:python)?\n[\s\S]*?\n```", text)
+    if len(blocks) != 1:
+        return False, f"expected exactly one fenced code block, found {len(blocks)}"
+    cleaned = re.sub(r"```(?:python)?\n[\s\S]*?\n```", "", text).strip()
+    if cleaned:
+        return False, "expected no text outside the code block"
+    return True, "ok"
+
+
+def check_group_anagrams_contract(text: str) -> tuple[bool, str]:
+    blocks = re.findall(r"```(?:python)?\n([\s\S]*?)\n```", text)
+    if len(blocks) != 1:
+        return False, "expected exactly one fenced code block"
+    code = blocks[0]
+    if "def group_anagrams(words: list[str]) -> list[list[str]]" not in code:
+        return False, "missing exact function signature"
+    if '"""' not in code and "'''" not in code:
+        return False, "missing docstring"
+    assert_count = len(re.findall(r"^\s*assert\s+", code, flags=re.MULTILINE))
+    if assert_count != 5:
+        return False, f"expected exactly 5 asserts, found {assert_count}"
+    return True, "ok"
+
+
+def check_exact_literal(text: str, literal: str) -> tuple[bool, str]:
+    if text.strip() != literal:
+        return False, f"expected exact literal {literal!r}"
+    return True, "ok"
+
+
+def run_case(endpoint: str, model: str, case: dict[str, Any]) -> CaseResult:
+    payload = {
+        "model": model,
+        "messages": [{"role": "user", "content": case["prompt"]}],
+        "temperature": 0,
+    }
+    t0 = time.time()
+    resp = http_json(endpoint.rstrip("/") + "/chat/completions", payload, timeout=180)
+    latency_ms = int((time.time() - t0) * 1000)
+    text = extract_text(resp)
+
+    check = case["check"]
+    if check == "exact_one_code_block":
+        ok, detail = check_exact_one_code_block(text)
+    elif check == "group_anagrams_contract":
+        ok, detail = check_group_anagrams_contract(text)
+    elif check == "exact_literal":
+        ok, detail = check_exact_literal(text, str(case["literal"]))
+    else:
+        ok, detail = False, f"unknown check: {check}"
+
+    preview = text[:180].replace("\n", "\\n")
+    return CaseResult(case_id=case["id"], ok=ok, latency_ms=latency_ms, detail=detail, output_preview=preview)
+
+
+def load_cases(path: Path) -> list[dict[str, Any]]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, list):
+        raise ValueError("cases file must be a JSON array")
+    return data
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run baseline prompt-contract suite against local model endpoints.")
+    parser.add_argument("--cases", default="scripts/model_baseline_cases.json", help="Path to JSON test cases.")
+    parser.add_argument("--out-json", default="scripts/output/model-baseline/baseline.latest.json", help="Output JSON path.")
+    parser.add_argument("--out-md", default="scripts/output/model-baseline/baseline.latest.md", help="Output markdown path.")
+    parser.add_argument(
+        "--models",
+        default="gemma,qwen2",
+        help="Comma-separated model keys from built-in endpoint map: gemma,qwen2",
+    )
+    args = parser.parse_args()
+
+    cases = load_cases(Path(args.cases))
+    selected = [m.strip() for m in args.models.split(",") if m.strip()]
+
+    report: dict[str, Any] = {
+        "report_type": "open-terminal-model-baseline",
+        "generated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "cases_path": str(Path(args.cases)),
+        "models": {},
+    }
+
+    md_lines = [
+        "# OpenTerminal Model Baseline",
+        "",
+        f"- generated_at: `{report['generated_at']}`",
+        f"- cases: `{args.cases}`",
+        "",
+    ]
+
+    for key in selected:
+        endpoint = DEFAULT_ENDPOINTS.get(key)
+        if not endpoint:
+            report["models"][key] = {"status": "unknown-model-key"}
+            md_lines.extend([f"## {key}", "", "- status: unknown model key", ""])
+            continue
+        try:
+            model_id = resolve_model_id(endpoint)
+        except (URLError, TimeoutError, OSError, json.JSONDecodeError) as exc:
+            report["models"][key] = {"status": "unreachable", "endpoint": endpoint, "error": str(exc)}
+            md_lines.extend([f"## {key}", "", f"- endpoint: `{endpoint}`", "- status: unreachable", f"- error: `{exc}`", ""])
+            continue
+
+        results: list[dict[str, Any]] = []
+        passed = 0
+        for case in cases:
+            try:
+                r = run_case(endpoint, model_id, case)
+            except Exception as exc:  # noqa: BLE001
+                r = CaseResult(case_id=case["id"], ok=False, latency_ms=0, detail=f"request-failed: {exc}", output_preview="")
+            passed += 1 if r.ok else 0
+            results.append(
+                {
+                    "case_id": r.case_id,
+                    "ok": r.ok,
+                    "latency_ms": r.latency_ms,
+                    "detail": r.detail,
+                    "output_preview": r.output_preview,
+                }
+            )
+
+        total = len(results)
+        compliance = round((passed / total) * 100, 1) if total else 0.0
+        avg_latency = int(sum(x["latency_ms"] for x in results) / total) if total else 0
+        report["models"][key] = {
+            "status": "ok",
+            "endpoint": endpoint,
+            "model_id": model_id,
+            "summary": {
+                "passed": passed,
+                "total": total,
+                "compliance_percent": compliance,
+                "avg_latency_ms": avg_latency,
+            },
+            "results": results,
+        }
+
+        md_lines.extend(
+            [
+                f"## {key}",
+                "",
+                f"- endpoint: `{endpoint}`",
+                f"- model_id: `{model_id}`",
+                f"- compliance: `{passed}/{total}` ({compliance}%)",
+                f"- avg_latency_ms: `{avg_latency}`",
+                "",
+                "| case | ok | latency_ms | detail |",
+                "|---|---:|---:|---|",
+            ]
+        )
+        for item in results:
+            md_lines.append(f"| `{item['case_id']}` | `{item['ok']}` | `{item['latency_ms']}` | {item['detail']} |")
+        md_lines.append("")
+
+    out_json = Path(args.out_json)
+    out_md = Path(args.out_md)
+    out_json.parent.mkdir(parents=True, exist_ok=True)
+    out_md.parent.mkdir(parents=True, exist_ok=True)
+    out_json.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    out_md.write_text("\n".join(md_lines).rstrip() + "\n", encoding="utf-8")
+
+    print(str(out_json))
+    print(str(out_md))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/model_baseline_suite.py
+++ b/scripts/model_baseline_suite.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import argparse
 import json
+import os
 import re
 import subprocess
 import sys
@@ -166,13 +167,25 @@ def main() -> int:
         "--mode",
         default="direct",
         choices=["direct", "harness"],
-        help="direct = call model endpoints directly, harness = call scripts/codex-gemma ask policy path",
+        help="direct = call model endpoints directly, harness = historical codex-gemma ask policy path (requires CODEX_GEMMA_ALLOW_HISTORICAL=1)",
     )
-    parser.add_argument("--retries", type=int, default=1, help="Harness mode retries passed to codex-gemma ask.")
+    parser.add_argument("--retries", type=int, default=1, help="Historical harness mode retries passed to codex-gemma ask.")
     args = parser.parse_args()
 
     cases = load_cases(Path(args.cases))
     selected = [m.strip() for m in args.models.split(",") if m.strip()]
+    historical_allowed = os.environ.get("CODEX_GEMMA_ALLOW_HISTORICAL") == "1"
+
+    if args.mode == "harness" and not historical_allowed:
+        print(
+            "Retired: codex-gemma harness mode is no longer part of the active Open Terminal operational path.",
+            file=sys.stderr,
+        )
+        print(
+            "Use packet-mediated local-worker delegation instead, or set CODEX_GEMMA_ALLOW_HISTORICAL=1 for historical benchmark/migration use.",
+            file=sys.stderr,
+        )
+        return 1
 
     report: dict[str, Any] = {
         "report_type": "open-terminal-model-baseline",
@@ -205,10 +218,10 @@ def main() -> int:
                 md_lines.extend([f"## {key}", "", f"- endpoint: `{endpoint}`", "- status: unreachable", f"- error: `{exc}`", ""])
                 continue
         else:
-            model_id = "codex-gemma-policy-path"
+            model_id = "codex-gemma-historical-policy-path"
             if key != "gemma":
-                report["models"][key] = {"status": "skipped", "reason": "harness mode currently routes through gemma entrypoint"}
-                md_lines.extend([f"## {key}", "", "- status: skipped", "- reason: harness mode routes through codex-gemma (gemma entrypoint).", ""])
+                report["models"][key] = {"status": "skipped", "reason": "historical harness mode currently routes through gemma entrypoint"}
+                md_lines.extend([f"## {key}", "", "- status: skipped", "- reason: historical harness mode routes through the codex-gemma gemma entrypoint.", ""])
                 continue
 
         results: list[dict[str, Any]] = []
@@ -237,7 +250,7 @@ def main() -> int:
         avg_latency = int(sum(x["latency_ms"] for x in results) / total) if total else 0
         report["models"][key] = {
             "status": "ok",
-            "endpoint": endpoint if args.mode == "direct" else "via-codex-gemma",
+            "endpoint": endpoint if args.mode == "direct" else "historical-via-codex-gemma",
             "model_id": model_id,
             "summary": {
                 "passed": passed,
@@ -252,7 +265,7 @@ def main() -> int:
             [
                 f"## {key}",
                 "",
-                f"- endpoint: `{endpoint if args.mode == 'direct' else 'via-codex-gemma'}`",
+                f"- endpoint: `{endpoint if args.mode == 'direct' else 'historical-via-codex-gemma'}`",
                 f"- model_id: `{model_id}`",
                 f"- compliance: `{passed}/{total}` ({compliance}%)",
                 f"- avg_latency_ms: `{avg_latency}`",

--- a/scripts/model_baseline_suite.py
+++ b/scripts/model_baseline_suite.py
@@ -2,6 +2,7 @@
 import argparse
 import json
 import re
+import subprocess
 import sys
 import time
 from dataclasses import dataclass
@@ -110,6 +111,40 @@ def run_case(endpoint: str, model: str, case: dict[str, Any]) -> CaseResult:
     return CaseResult(case_id=case["id"], ok=ok, latency_ms=latency_ms, detail=detail, output_preview=preview)
 
 
+def run_case_via_harness(case: dict[str, Any], retries: int) -> CaseResult:
+    cmd = [
+        "scripts/codex-gemma",
+        "ask",
+        "--policy",
+        "strict",
+        "--retries",
+        str(retries),
+        "--fallback",
+        "none",
+        "--single-model-lock",
+        "on",
+        case["prompt"],
+    ]
+    t0 = time.time()
+    p = subprocess.run(cmd, capture_output=True, text=True)
+    latency_ms = int((time.time() - t0) * 1000)
+    if p.returncode != 0:
+        detail = f"harness-failed: {p.stderr.strip() or p.stdout.strip()}"
+        return CaseResult(case_id=case["id"], ok=False, latency_ms=latency_ms, detail=detail, output_preview="")
+    text = p.stdout.strip()
+    check = case["check"]
+    if check == "exact_one_code_block":
+        ok, detail = check_exact_one_code_block(text)
+    elif check == "group_anagrams_contract":
+        ok, detail = check_group_anagrams_contract(text)
+    elif check == "exact_literal":
+        ok, detail = check_exact_literal(text, str(case["literal"]))
+    else:
+        ok, detail = False, f"unknown check: {check}"
+    preview = text[:180].replace("\n", "\\n")
+    return CaseResult(case_id=case["id"], ok=ok, latency_ms=latency_ms, detail=detail, output_preview=preview)
+
+
 def load_cases(path: Path) -> list[dict[str, Any]]:
     data = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(data, list):
@@ -127,6 +162,13 @@ def main() -> int:
         default="gemma,qwen2",
         help="Comma-separated model keys from built-in endpoint map: gemma,qwen2",
     )
+    parser.add_argument(
+        "--mode",
+        default="direct",
+        choices=["direct", "harness"],
+        help="direct = call model endpoints directly, harness = call scripts/codex-gemma ask policy path",
+    )
+    parser.add_argument("--retries", type=int, default=1, help="Harness mode retries passed to codex-gemma ask.")
     args = parser.parse_args()
 
     cases = load_cases(Path(args.cases))
@@ -136,6 +178,7 @@ def main() -> int:
         "report_type": "open-terminal-model-baseline",
         "generated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
         "cases_path": str(Path(args.cases)),
+        "mode": args.mode,
         "models": {},
     }
 
@@ -144,27 +187,38 @@ def main() -> int:
         "",
         f"- generated_at: `{report['generated_at']}`",
         f"- cases: `{args.cases}`",
+        f"- mode: `{args.mode}`",
         "",
     ]
 
     for key in selected:
         endpoint = DEFAULT_ENDPOINTS.get(key)
-        if not endpoint:
-            report["models"][key] = {"status": "unknown-model-key"}
-            md_lines.extend([f"## {key}", "", "- status: unknown model key", ""])
-            continue
-        try:
-            model_id = resolve_model_id(endpoint)
-        except (URLError, TimeoutError, OSError, json.JSONDecodeError) as exc:
-            report["models"][key] = {"status": "unreachable", "endpoint": endpoint, "error": str(exc)}
-            md_lines.extend([f"## {key}", "", f"- endpoint: `{endpoint}`", "- status: unreachable", f"- error: `{exc}`", ""])
-            continue
+        if args.mode == "direct":
+            if not endpoint:
+                report["models"][key] = {"status": "unknown-model-key"}
+                md_lines.extend([f"## {key}", "", "- status: unknown model key", ""])
+                continue
+            try:
+                model_id = resolve_model_id(endpoint)
+            except (URLError, TimeoutError, OSError, json.JSONDecodeError) as exc:
+                report["models"][key] = {"status": "unreachable", "endpoint": endpoint, "error": str(exc)}
+                md_lines.extend([f"## {key}", "", f"- endpoint: `{endpoint}`", "- status: unreachable", f"- error: `{exc}`", ""])
+                continue
+        else:
+            model_id = "codex-gemma-policy-path"
+            if key != "gemma":
+                report["models"][key] = {"status": "skipped", "reason": "harness mode currently routes through gemma entrypoint"}
+                md_lines.extend([f"## {key}", "", "- status: skipped", "- reason: harness mode routes through codex-gemma (gemma entrypoint).", ""])
+                continue
 
         results: list[dict[str, Any]] = []
         passed = 0
         for case in cases:
             try:
-                r = run_case(endpoint, model_id, case)
+                if args.mode == "direct":
+                    r = run_case(endpoint, model_id, case)
+                else:
+                    r = run_case_via_harness(case, args.retries)
             except Exception as exc:  # noqa: BLE001
                 r = CaseResult(case_id=case["id"], ok=False, latency_ms=0, detail=f"request-failed: {exc}", output_preview="")
             passed += 1 if r.ok else 0
@@ -183,7 +237,7 @@ def main() -> int:
         avg_latency = int(sum(x["latency_ms"] for x in results) / total) if total else 0
         report["models"][key] = {
             "status": "ok",
-            "endpoint": endpoint,
+            "endpoint": endpoint if args.mode == "direct" else "via-codex-gemma",
             "model_id": model_id,
             "summary": {
                 "passed": passed,
@@ -198,7 +252,7 @@ def main() -> int:
             [
                 f"## {key}",
                 "",
-                f"- endpoint: `{endpoint}`",
+                f"- endpoint: `{endpoint if args.mode == 'direct' else 'via-codex-gemma'}`",
                 f"- model_id: `{model_id}`",
                 f"- compliance: `{passed}/{total}` ({compliance}%)",
                 f"- avg_latency_ms: `{avg_latency}`",

--- a/scripts/open-terminal
+++ b/scripts/open-terminal
@@ -22,7 +22,6 @@ OT_CURRENT_SESSION_ID=""
 OT_STATUS_PROMPT="${OT_STATUS_PROMPT:-1}"
 OT_CONTRACT_MODE="${OT_CONTRACT_MODE:-strict}"
 OT_CHAT_RETRY_MAX="${OT_CHAT_RETRY_MAX:-2}"
-CODEX_GEMMA_BIN="${CODEX_GEMMA_BIN:-$ROOT_DIR/scripts/codex-gemma}"
 OT_PRETTY_OUTPUT="${OT_PRETTY_OUTPUT:-auto}"
 mkdir -p "$OT_STATE_DIR" "$OT_CONFIG_DIR" "$OT_SESSIONS_DIR"
 
@@ -114,14 +113,14 @@ COMMANDS=(
   "/session new [name]"
   "/session use <id>"
   "/clear"
-  "/run <task>"
-  "/jobs"
+  "/run <task> (retired)"
+  "/jobs (retired)"
   "/ps"
-  "/job status <job_id>"
-  "/job wait <job_id>"
-  "/job result <job_id>"
-  "/job logs <job_id>"
-  "/job cancel <job_id>"
+  "/job status <job_id> (retired)"
+  "/job wait <job_id> (retired)"
+  "/job result <job_id> (retired)"
+  "/job logs <job_id> (retired)"
+  "/job cancel <job_id> (retired)"
   "/contract"
   "/contract strict|off"
   "/statusline"
@@ -144,7 +143,7 @@ Usage:
   open-terminal model [profile]
   open-terminal mode [chat|raw]
   open-terminal menu [meta|system|model|chat|session|jobs|safety]
-  open-terminal run "<task>"
+  open-terminal run "<task>"         # retired; packet-mediated delegation replaces this
   open-terminal jobs
   open-terminal job status|wait|result|logs|cancel <job_id>
   open-terminal contract [strict|off]
@@ -186,14 +185,14 @@ Slash commands inside REPL:
   /session list
   /session new [name]
   /session use <id>
-  /run <task>          # async orchestration job via codex-gemma
-  /jobs
+  /run <task>          # retired; use packet-mediated local-worker delegation instead
+  /jobs                # retired
   /ps                 # quick background process view
-  /job status <job_id>
-  /job wait <job_id>
-  /job result <job_id>
-  /job logs <job_id>
-  /job cancel <job_id>
+  /job status <job_id>  # retired
+  /job wait <job_id>    # retired
+  /job result <job_id>  # retired
+  /job logs <job_id>    # retired
+  /job cancel <job_id>  # retired
   /contract [strict|off]
   /statusline [on|off]
   /clear              # clear local chat history
@@ -235,14 +234,14 @@ command_description() {
     "/session new [name]") echo "Create a new session." ;;
     "/session use <id>") echo "Switch to an existing session." ;;
     "/clear") echo "Clear active session history file." ;;
-    "/run <task>") echo "Start async codex-gemma worker job." ;;
-    "/jobs") echo "List async jobs." ;;
+    "/run <task>") echo "Retired: use packet-mediated local-worker delegation instead." ;;
+    "/jobs") echo "Retired: no codex-gemma async job queue remains active." ;;
     "/ps") echo "Show background jobs and watcher service status." ;;
-    "/job status <job_id>") echo "Show job metadata and state." ;;
-    "/job wait <job_id>") echo "Wait for job completion." ;;
-    "/job result <job_id>") echo "Print job result output." ;;
-    "/job logs <job_id>") echo "Tail/read job log output." ;;
-    "/job cancel <job_id>") echo "Cancel async job via systemd unit." ;;
+    "/job status <job_id>") echo "Retired: async codex-gemma jobs are no longer part of active usage." ;;
+    "/job wait <job_id>") echo "Retired: async codex-gemma jobs are no longer part of active usage." ;;
+    "/job result <job_id>") echo "Retired: async codex-gemma jobs are no longer part of active usage." ;;
+    "/job logs <job_id>") echo "Retired: async codex-gemma jobs are no longer part of active usage." ;;
+    "/job cancel <job_id>") echo "Retired: async codex-gemma jobs are no longer part of active usage." ;;
     "/contract") echo "Show strict contract mode status." ;;
     "/contract strict|off") echo "Enable/disable strict output validation." ;;
     "/statusline") echo "Show status-line setting." ;;
@@ -956,19 +955,16 @@ do_run() {
     echo "Usage: /run <task>"
     return 1
   fi
-  if [[ ! -x "$CODEX_GEMMA_BIN" ]]; then
-    echo "codex-gemma helper not found at $CODEX_GEMMA_BIN"
-    return 1
-  fi
-  "$CODEX_GEMMA_BIN" orchestrate "$task" --max-refine 1 --async
+  echo "Retired: codex-gemma is no longer part of the active Open Terminal operational path."
+  echo "Use packet-mediated local-worker delegation instead."
+  echo "If you need the historical wrapper for a benchmark, invoke scripts/codex-gemma directly with CODEX_GEMMA_ALLOW_HISTORICAL=1."
+  return 1
 }
 
 do_jobs() {
-  if [[ ! -x "$CODEX_GEMMA_BIN" ]]; then
-    echo "codex-gemma helper not found at $CODEX_GEMMA_BIN"
-    return 1
-  fi
-  "$CODEX_GEMMA_BIN" jobs
+  echo "Retired: codex-gemma async jobs are no longer part of the active Open Terminal operational path."
+  echo "Historical job inspection should be done only if CODEX_GEMMA_ALLOW_HISTORICAL=1 is set for a benchmark."
+  return 1
 }
 
 do_ps() {
@@ -992,20 +988,9 @@ do_stop_target() {
       echo "Stopped midnight-dust-watcher.service"
       ;;
     all-jobs)
-      if [[ ! -d "$CG_STATE_DIR/codex-gemma-jobs" ]]; then
-        echo "No async jobs directory found."
-        return 0
-      fi
-      local stopped=0
-      for meta in "$CG_STATE_DIR"/codex-gemma-jobs/*.meta; do
-        [[ -f "$meta" ]] || continue
-        unit="$(sed -n 's/^unit=//p' "$meta" | tail -n1)"
-        if [[ -n "$unit" ]]; then
-          systemctl --user stop "$unit" || true
-          stopped=$((stopped + 1))
-        fi
-      done
-      echo "Requested stop for $stopped async job unit(s)."
+      echo "Retired: codex-gemma async job cleanup is no longer part of the active Open Terminal operational path."
+      echo "If you need to clean up historical artifacts, remove them manually from ~/.local/state/open-terminal/codex-gemma-jobs."
+      return 1
       ;;
     *)
       do_job cancel "$target"
@@ -1020,42 +1005,28 @@ do_job() {
   case "$sub" in
     status)
       [[ -n "$job_id" ]] || { echo "Usage: /job status <job_id>"; return 1; }
-      "$CODEX_GEMMA_BIN" status-job "$job_id"
+      echo "Retired: codex-gemma job status is no longer part of the active Open Terminal operational path."
+      return 1
       ;;
     wait)
       [[ -n "$job_id" ]] || { echo "Usage: /job wait <job_id>"; return 1; }
-      "$CODEX_GEMMA_BIN" wait "$job_id"
+      echo "Retired: codex-gemma job wait is no longer part of the active Open Terminal operational path."
+      return 1
       ;;
     logs)
       [[ -n "$job_id" ]] || { echo "Usage: /job logs <job_id>"; return 1; }
-      log="$CG_STATE_DIR/codex-gemma-jobs/${job_id}.log"
-      [[ -f "$log" ]] || { echo "No log file yet: $log"; return 1; }
-      local tmp_log
-      tmp_log="$(mktemp)"
-      tail -n 120 "$log" > "$tmp_log"
-      pretty_print_file "$tmp_log" plain
-      rm -f "$tmp_log"
+      echo "Retired: codex-gemma job logs are no longer part of the active Open Terminal operational path."
+      return 1
       ;;
     result)
       [[ -n "$job_id" ]] || { echo "Usage: /job result <job_id>"; return 1; }
-      result="$CG_STATE_DIR/codex-gemma-jobs/${job_id}.result.md"
-      [[ -f "$result" ]] || { echo "No result file yet: $result"; return 1; }
-      if rg -q '^(\+\+\+ |--- |@@ )' "$result" 2>/dev/null; then
-        pretty_print_file "$result" diff
-      else
-        pretty_print_file "$result" plain
-      fi
+      echo "Retired: codex-gemma job results are no longer part of the active Open Terminal operational path."
+      return 1
       ;;
     cancel)
       [[ -n "$job_id" ]] || { echo "Usage: /job cancel <job_id>"; return 1; }
-      unit="$(job_read_meta_value "$job_id" unit || true)"
-      if [[ -z "$unit" ]]; then
-        echo "No systemd unit recorded for $job_id."
-        echo "Remediation: check /job status $job_id and stop manually if needed."
-        return 1
-      fi
-      systemctl --user stop "$unit"
-      echo "Requested cancel for $job_id ($unit)"
+      echo "Retired: codex-gemma job cancellation is no longer part of the active Open Terminal operational path."
+      return 1
       ;;
     *)
       echo "Usage: /job status|wait|result|logs|cancel <job_id>"

--- a/scripts/open-terminal
+++ b/scripts/open-terminal
@@ -19,6 +19,10 @@ OT_AUTO_RETURN_TO_GEMMA=0
 OT_CHAT_MODE="${OT_CHAT_MODE:-chat}"
 OT_LAST_PAYLOAD=""
 OT_CURRENT_SESSION_ID=""
+OT_STATUS_PROMPT="${OT_STATUS_PROMPT:-1}"
+OT_CONTRACT_MODE="${OT_CONTRACT_MODE:-strict}"
+OT_CHAT_RETRY_MAX="${OT_CHAT_RETRY_MAX:-2}"
+CODEX_GEMMA_BIN="${CODEX_GEMMA_BIN:-$ROOT_DIR/scripts/codex-gemma}"
 mkdir -p "$OT_STATE_DIR" "$OT_CONFIG_DIR" "$OT_SESSIONS_DIR"
 
 COMMANDS=(
@@ -53,6 +57,17 @@ COMMANDS=(
   "/session new [name]"
   "/session use <id>"
   "/clear"
+  "/run <task>"
+  "/jobs"
+  "/job status <job_id>"
+  "/job wait <job_id>"
+  "/job result <job_id>"
+  "/job logs <job_id>"
+  "/job cancel <job_id>"
+  "/contract"
+  "/contract strict|off"
+  "/statusline"
+  "/statusline on|off"
   "/quit"
 )
 
@@ -70,6 +85,11 @@ Usage:
   open-terminal start|stop|restart|status|logs|health|verify
   open-terminal model [profile]
   open-terminal mode [chat|raw]
+  open-terminal run "<task>"
+  open-terminal jobs
+  open-terminal job status|wait|result|logs|cancel <job_id>
+  open-terminal contract [strict|off]
+  open-terminal statusline [on|off]
   open-terminal raw "<prompt>"
   open-terminal diag-prompt [text]
   open-terminal history [N]
@@ -100,6 +120,15 @@ Slash commands inside REPL:
   /session list
   /session new [name]
   /session use <id>
+  /run <task>          # async orchestration job via codex-gemma
+  /jobs
+  /job status <job_id>
+  /job wait <job_id>
+  /job result <job_id>
+  /job logs <job_id>
+  /job cancel <job_id>
+  /contract [strict|off]
+  /statusline [on|off]
   /clear              # clear local chat history
   /help
   /quit
@@ -198,11 +227,21 @@ load_mode_state() {
     if [[ "${OT_SAVED_MODE:-}" == "chat" || "${OT_SAVED_MODE:-}" == "raw" ]]; then
       OT_CHAT_MODE="$OT_SAVED_MODE"
     fi
+    if [[ "${OT_SAVED_STATUS_PROMPT:-}" == "0" || "${OT_SAVED_STATUS_PROMPT:-}" == "1" ]]; then
+      OT_STATUS_PROMPT="$OT_SAVED_STATUS_PROMPT"
+    fi
+    if [[ "${OT_SAVED_CONTRACT_MODE:-}" == "strict" || "${OT_SAVED_CONTRACT_MODE:-}" == "off" ]]; then
+      OT_CONTRACT_MODE="$OT_SAVED_CONTRACT_MODE"
+    fi
   fi
 }
 
 save_mode_state() {
-  printf 'OT_SAVED_MODE=%s\n' "$OT_CHAT_MODE" > "$OT_MODE_STATE_FILE"
+  {
+    printf 'OT_SAVED_MODE=%s\n' "$OT_CHAT_MODE"
+    printf 'OT_SAVED_STATUS_PROMPT=%s\n' "$OT_STATUS_PROMPT"
+    printf 'OT_SAVED_CONTRACT_MODE=%s\n' "$OT_CONTRACT_MODE"
+  } > "$OT_MODE_STATE_FILE"
 }
 
 init_state() {
@@ -252,6 +291,19 @@ current_endpoint() {
 
 show_endpoint() {
   echo "Current model endpoint: $(current_endpoint)"
+}
+
+prompt_status() {
+  if [[ "$OT_STATUS_PROMPT" -ne 1 ]]; then
+    printf 'open-terminal> '
+    return
+  fi
+  local endpoint model cwd short_cwd
+  endpoint="$(current_endpoint)"
+  model="$(current_model_id)"
+  cwd="$(pwd)"
+  short_cwd="${cwd/#$HOME/~}"
+  printf 'open-terminal[%s|%s|%s]> ' "$OT_CHAT_MODE" "$model" "$short_cwd"
 }
 
 show_commands() {
@@ -340,7 +392,7 @@ current_model_id() {
   local endpoint models_url id
   endpoint="$(current_endpoint)"
   models_url="${endpoint%/}/models"
-  id="$(curl -fsS "$models_url" 2>/dev/null | python3 - <<'PY'
+  id="$(curl --max-time 1 -fsS "$models_url" 2>/dev/null | python3 - <<'PY'
 import json,sys
 try:
     data=json.load(sys.stdin)
@@ -417,35 +469,111 @@ print(msg if isinstance(msg,str) else str(msg))
 PY
 }
 
+validate_contract() {
+  local prompt="$1"
+  local candidate="$2"
+  python3 - "$prompt" "$candidate" <<'PY'
+import re, sys
+prompt = sys.argv[1].lower()
+candidate = sys.argv[2]
+
+def fail(msg: str):
+    print(msg)
+    raise SystemExit(1)
+
+if "exactly one runnable python code block" in prompt:
+    blocks = re.findall(r"```(?:python)?\n[\s\S]*?\n```", candidate)
+    if len(blocks) != 1:
+        fail("expected exactly one fenced code block")
+    cleaned = re.sub(r"```(?:python)?\n[\s\S]*?\n```", "", candidate).strip()
+    if cleaned:
+        fail("expected no text outside code block")
+
+if "nothing else" in prompt:
+    if "```" in candidate:
+        pass
+    else:
+        lines = [ln for ln in candidate.splitlines() if ln.strip()]
+        if len(lines) != 1:
+            fail("expected exactly one non-empty line")
+
+if "print exactly this string and nothing else:" in prompt:
+    m = re.search(r"print exactly this string and nothing else:\s*([A-Za-z0-9_\-]+)", prompt)
+    if m:
+        target = m.group(1).strip()
+        if candidate.strip() != target:
+            fail(f"expected exact literal '{target}'")
+
+print("ok")
+PY
+}
+
+repair_prompt_for_contract() {
+  local original_prompt="$1"
+  local bad_output="$2"
+  cat <<EOF
+You must repair a prior response that violated formatting constraints.
+
+Original user prompt:
+$original_prompt
+
+Invalid prior response:
+$bad_output
+
+Return a corrected answer that strictly follows every formatting instruction in the original prompt.
+Do not explain. Output only the corrected final answer.
+EOF
+}
+
 chat_send() {
   local user_text="$1"
   local force_mode="${2:-}"
-  local endpoint chat_url model payload resp assistant mode
+  local endpoint chat_url model payload resp assistant mode attempt validation_msg retry_prompt
   endpoint="$(current_endpoint)"
   chat_url="${endpoint%/}/chat/completions"
   model="$(current_model_id)"
   mode="${force_mode:-$OT_CHAT_MODE}"
 
-  payload="$(build_payload "$mode" "$user_text" "$model")"
-  OT_LAST_PAYLOAD="$payload"
+  retry_prompt="$user_text"
+  for (( attempt=1; attempt<=OT_CHAT_RETRY_MAX+1; attempt++ )); do
+    payload="$(build_payload "$mode" "$retry_prompt" "$model")"
+    OT_LAST_PAYLOAD="$payload"
 
-  resp="$(curl -fsS \
-    -H 'Content-Type: application/json' \
-    -H 'Authorization: Bearer dummy' \
-    -d "$payload" \
-    "$chat_url" 2>&1)" || {
-      echo "Chat request failed against $chat_url"
-      echo "$resp"
-      echo "Tip: run /model and select a profile with a live endpoint."
+    resp="$(curl -fsS \
+      -H 'Content-Type: application/json' \
+      -H 'Authorization: Bearer dummy' \
+      -d "$payload" \
+      "$chat_url" 2>&1)" || {
+        echo "Chat request failed against $chat_url"
+        echo "$resp"
+        echo "Remediation: run /endpoint-check, then /model gemma (or another live profile), then retry."
+        return 1
+      }
+
+    assistant="$(extract_assistant_text "$resp")"
+    if [[ -z "$assistant" ]]; then
+      if (( attempt <= OT_CHAT_RETRY_MAX )); then
+        retry_prompt="Return a direct answer only. No meta text. Original request: $user_text"
+        continue
+      fi
+      echo "No assistant content returned."
+      echo "Remediation: run /diag prompt to inspect payload, then retry with /raw <prompt>."
       return 1
-    }
+    fi
 
-  assistant="$(extract_assistant_text "$resp")"
-
-  if [[ -z "$assistant" ]]; then
-    echo "No assistant content returned."
-    return 1
-  fi
+    if [[ "$OT_CONTRACT_MODE" == "strict" ]]; then
+      if ! validation_msg="$(validate_contract "$user_text" "$assistant" 2>&1)"; then
+        if (( attempt <= OT_CHAT_RETRY_MAX )); then
+          retry_prompt="$(repair_prompt_for_contract "$user_text" "$assistant")"
+          continue
+        fi
+        echo "Response contract check failed: $validation_msg"
+        echo "Remediation: use /raw with stricter constraints or switch model via /model."
+        return 1
+      fi
+    fi
+    break
+  done
 
   if [[ "$mode" == "chat" ]]; then
     printf '{"role":"user","content":%s}\n' "$(python3 -c 'import json,sys; print(json.dumps(sys.argv[1]))' "$user_text")" >> "$CHAT_HISTORY_FILE"
@@ -458,6 +586,111 @@ chat_send() {
     echo "Auto-returning to Gemma primary..."
     do_model gemma || true
   fi
+}
+
+do_contract() {
+  local target="${1:-}"
+  if [[ -z "$target" ]]; then
+    echo "Contract mode: $OT_CONTRACT_MODE"
+    return 0
+  fi
+  case "$target" in
+    strict|off)
+      OT_CONTRACT_MODE="$target"
+      save_mode_state
+      echo "Contract mode set to: $OT_CONTRACT_MODE"
+      ;;
+    *) echo "Usage: /contract [strict|off]"; return 1 ;;
+  esac
+}
+
+do_statusline() {
+  local target="${1:-}"
+  if [[ -z "$target" ]]; then
+    if [[ "$OT_STATUS_PROMPT" -eq 1 ]]; then
+      echo "Status line: on"
+    else
+      echo "Status line: off"
+    fi
+    return 0
+  fi
+  case "$target" in
+    on) OT_STATUS_PROMPT=1; save_mode_state; echo "Status line enabled." ;;
+    off) OT_STATUS_PROMPT=0; save_mode_state; echo "Status line disabled." ;;
+    *) echo "Usage: /statusline [on|off]"; return 1 ;;
+  esac
+}
+
+job_read_meta_value() {
+  local job_id="$1"
+  local key="$2"
+  local meta="$CG_STATE_DIR/codex-gemma-jobs/${job_id}.meta"
+  [[ -f "$meta" ]] || return 1
+  sed -n "s/^${key}=//p" "$meta" | tail -n1
+}
+
+do_run() {
+  local task="${1:-}"
+  if [[ -z "$task" ]]; then
+    echo "Usage: /run <task>"
+    return 1
+  fi
+  if [[ ! -x "$CODEX_GEMMA_BIN" ]]; then
+    echo "codex-gemma helper not found at $CODEX_GEMMA_BIN"
+    return 1
+  fi
+  "$CODEX_GEMMA_BIN" orchestrate "$task" --max-refine 1 --async
+}
+
+do_jobs() {
+  if [[ ! -x "$CODEX_GEMMA_BIN" ]]; then
+    echo "codex-gemma helper not found at $CODEX_GEMMA_BIN"
+    return 1
+  fi
+  "$CODEX_GEMMA_BIN" jobs
+}
+
+do_job() {
+  local sub="${1:-}"
+  local job_id="${2:-}"
+  local meta unit log result
+  case "$sub" in
+    status)
+      [[ -n "$job_id" ]] || { echo "Usage: /job status <job_id>"; return 1; }
+      "$CODEX_GEMMA_BIN" status-job "$job_id"
+      ;;
+    wait)
+      [[ -n "$job_id" ]] || { echo "Usage: /job wait <job_id>"; return 1; }
+      "$CODEX_GEMMA_BIN" wait "$job_id"
+      ;;
+    logs)
+      [[ -n "$job_id" ]] || { echo "Usage: /job logs <job_id>"; return 1; }
+      log="$CG_STATE_DIR/codex-gemma-jobs/${job_id}.log"
+      [[ -f "$log" ]] || { echo "No log file yet: $log"; return 1; }
+      tail -n 120 "$log"
+      ;;
+    result)
+      [[ -n "$job_id" ]] || { echo "Usage: /job result <job_id>"; return 1; }
+      result="$CG_STATE_DIR/codex-gemma-jobs/${job_id}.result.md"
+      [[ -f "$result" ]] || { echo "No result file yet: $result"; return 1; }
+      cat "$result"
+      ;;
+    cancel)
+      [[ -n "$job_id" ]] || { echo "Usage: /job cancel <job_id>"; return 1; }
+      unit="$(job_read_meta_value "$job_id" unit || true)"
+      if [[ -z "$unit" ]]; then
+        echo "No systemd unit recorded for $job_id."
+        echo "Remediation: check /job status $job_id and stop manually if needed."
+        return 1
+      fi
+      systemctl --user stop "$unit"
+      echo "Requested cancel for $job_id ($unit)"
+      ;;
+    *)
+      echo "Usage: /job status|wait|result|logs|cancel <job_id>"
+      return 1
+      ;;
+  esac
 }
 
 do_mode() {
@@ -550,7 +783,7 @@ run_repl() {
   setup_readline_bindings
 
   while true; do
-    read -e -rp "open-terminal> " line || break
+    read -e -rp "$(prompt_status)" line || break
     case "$line" in
       "" ) continue ;;
       "/help" ) usage ;;
@@ -565,6 +798,12 @@ run_repl() {
       "/endpoint-check" ) check_endpoint ;;
       "/verify" ) do_verify || true ;;
       "/clear" ) do_clear ;;
+      "/contract" ) do_contract ;;
+      /contract\ strict ) do_contract strict ;;
+      /contract\ off ) do_contract off ;;
+      "/statusline" ) do_statusline ;;
+      /statusline\ on ) do_statusline on ;;
+      /statusline\ off ) do_statusline off ;;
       "/history" ) history_show ;;
       /history\ * ) history_show "${line#"/history "}" ;;
       "/resume --all" ) resume_all ;;
@@ -572,6 +811,13 @@ run_repl() {
       "/session new" ) session_new ;;
       /session\ new\ * ) session_new "${line#"/session new "}" ;;
       /session\ use\ * ) session_use "${line#"/session use "}" ;;
+      /run\ * ) do_run "${line#"/run "}" ;;
+      "/jobs" ) do_jobs ;;
+      /job\ status\ * ) do_job status "${line#"/job status "}" ;;
+      /job\ wait\ * ) do_job wait "${line#"/job wait "}" ;;
+      /job\ result\ * ) do_job result "${line#"/job result "}" ;;
+      /job\ logs\ * ) do_job logs "${line#"/job logs "}" ;;
+      /job\ cancel\ * ) do_job cancel "${line#"/job cancel "}" ;;
       "/mode" ) do_mode ;;
       /mode\ chat ) do_mode chat ;;
       /mode\ raw ) do_mode raw ;;
@@ -610,6 +856,21 @@ run_repl() {
       /mode* )
         echo "Usage: /mode [chat|raw]"
         ;;
+      /contract* )
+        echo "Usage: /contract [strict|off]"
+        ;;
+      /statusline* )
+        echo "Usage: /statusline [on|off]"
+        ;;
+      /run )
+        echo "Usage: /run <task>"
+        ;;
+      /jobs* )
+        echo "Usage: /jobs"
+        ;;
+      /job* )
+        echo "Usage: /job status|wait|result|logs|cancel <job_id>"
+        ;;
       /session* )
         echo "Usage: /session list | /session new [name] | /session use <id>"
         ;;
@@ -638,6 +899,27 @@ main() {
     health) do_health ;;
     endpoint) show_endpoint ;;
     endpoint-check) check_endpoint ;;
+    run)
+      shift || true
+      if [[ -z "${*:-}" ]]; then
+        echo "Usage: open-terminal run <task>"
+        exit 1
+      fi
+      do_run "${*}"
+      ;;
+    jobs) do_jobs ;;
+    job)
+      shift || true
+      do_job "${1:-}" "${2:-}"
+      ;;
+    contract)
+      shift || true
+      do_contract "${1:-}"
+      ;;
+    statusline)
+      shift || true
+      do_statusline "${1:-}"
+      ;;
     mode)
       shift || true
       do_mode "${1:-}"

--- a/scripts/open-terminal
+++ b/scripts/open-terminal
@@ -632,7 +632,7 @@ slash_tab_complete() {
 setup_readline_bindings() {
   # Bind TAB (Ctrl+I) to slash command completion cycling.
   if [[ -t 0 && -t 1 ]]; then
-    bind -x '"\C-i":slash_tab_complete'
+    bind -x '"\C-i":slash_tab_complete' 2>/dev/null || true
   fi
 }
 

--- a/scripts/open-terminal
+++ b/scripts/open-terminal
@@ -27,6 +27,7 @@ mkdir -p "$OT_STATE_DIR" "$OT_CONFIG_DIR" "$OT_SESSIONS_DIR"
 
 COMMANDS=(
   "/help"
+  "/menu"
   "/q"
   "/start"
   "/stop"
@@ -85,6 +86,7 @@ Usage:
   open-terminal start|stop|restart|status|logs|health|verify
   open-terminal model [profile]
   open-terminal mode [chat|raw]
+  open-terminal menu
   open-terminal run "<task>"
   open-terminal jobs
   open-terminal job status|wait|result|logs|cancel <job_id>
@@ -99,6 +101,7 @@ Usage:
 
 Slash commands inside REPL:
   /
+  /menu                # interactive command picker
   /<prefix>           # filter commands, e.g. /m
   TAB                 # cycle matching slash commands
   /start
@@ -336,6 +339,35 @@ show_commands() {
   fi
 }
 
+pick_command_interactive() {
+  local selection=""
+  if command -v fzf >/dev/null 2>&1; then
+    selection="$(printf '%s\n' "${COMMANDS[@]}" | fzf --prompt='slash> ' --height=40% --layout=reverse --border || true)"
+  else
+    echo "Interactive menu (fzf not installed, using numbered picker):" >&2
+    local i=1
+    local cmd
+    for cmd in "${COMMANDS[@]}"; do
+      printf '%2d) %s\n' "$i" "$cmd" >&2
+      i=$((i + 1))
+    done
+    read -r -p "Choice [1-$((i-1))]: " choice >&2
+    if [[ "${choice:-}" =~ ^[0-9]+$ ]] && (( choice >= 1 && choice < i )); then
+      selection="${COMMANDS[$((choice-1))]}"
+    fi
+  fi
+  printf '%s' "$selection"
+}
+
+canonicalize_menu_choice() {
+  local selected="$1"
+  case "$selected" in
+    "/model qwen (on-demand warm-up)") echo "/model qwen" ;;
+    "/model qwen-temp (one reply, then auto-return to gemma)") echo "/model qwen-temp" ;;
+    *) echo "$selected" ;;
+  esac
+}
+
 build_command_matches() {
   local prefix="$1"
   local normalized="${prefix#/}"
@@ -503,6 +535,30 @@ if "print exactly this string and nothing else:" in prompt:
         target = m.group(1).strip()
         if candidate.strip() != target:
             fail(f"expected exact literal '{target}'")
+
+if "def group_anagrams(words: list[str]) -> list[list[str]]" in prompt:
+    if "```" not in candidate:
+        fail("expected fenced python code block for group_anagrams task")
+    blocks = re.findall(r"```(?:python)?\n([\s\S]*?)\n```", candidate)
+    if len(blocks) != 1:
+        fail("expected exactly one code block")
+    code = blocks[0]
+    if "def group_anagrams(words: list[str]) -> list[list[str]]" not in code:
+        fail("missing exact function signature")
+    if '"""' not in code and "'''" not in code:
+        fail("missing docstring")
+    assert_count = len(re.findall(r"^\s*assert\s+", code, flags=re.MULTILINE))
+    if assert_count != 5:
+        fail(f"expected exactly 5 assert tests, found {assert_count}")
+    needed = [
+        "case-insensitive",
+        "non-alphabetic",
+        "preserve",
+        "empty input",
+    ]
+    lowered = code.lower()
+    if sum(1 for item in needed if item in lowered) < 2:
+        fail("code/comments/tests appear to miss key requirements coverage")
 
 print("ok")
 PY
@@ -787,6 +843,24 @@ run_repl() {
     case "$line" in
       "" ) continue ;;
       "/help" ) usage ;;
+      "/menu" )
+        picked="$(pick_command_interactive)"
+        if [[ -z "$picked" ]]; then
+          echo "No command selected."
+        else
+          picked="$(canonicalize_menu_choice "$picked")"
+          echo "Selected: $picked"
+          case "$picked" in
+            "/start"|"/stop"|"/restart"|"/status"|"/logs"|"/health"|"/verify"|"/endpoint"|"/endpoint-check"|"/model"|"/models"|"/mode"|"/history"|"/resume --all"|"/session list"|"/session new"|"/jobs"|"/contract"|"/statusline"|"/help"|"/clear")
+              line="$picked"
+              ;;
+            *)
+              echo "This command needs extra input. Run it directly: $picked"
+              continue
+              ;;
+          esac
+        fi
+        ;;
       "/quit"|"/exit"|"/q" ) break ;;
       "/start" ) do_start ;;
       "/stop" ) do_stop ;;
@@ -874,7 +948,24 @@ run_repl() {
       /session* )
         echo "Usage: /session list | /session new [name] | /session use <id>"
         ;;
-      "/" ) show_commands "/" ;;
+      "/" )
+        picked="$(pick_command_interactive)"
+        if [[ -z "$picked" ]]; then
+          show_commands "/"
+        else
+          picked="$(canonicalize_menu_choice "$picked")"
+          echo "Selected: $picked"
+          case "$picked" in
+            "/start"|"/stop"|"/restart"|"/status"|"/logs"|"/health"|"/verify"|"/endpoint"|"/endpoint-check"|"/model"|"/models"|"/mode"|"/history"|"/resume --all"|"/session list"|"/session new"|"/jobs"|"/contract"|"/statusline"|"/help"|"/clear")
+              line="$picked"
+              ;;
+            *)
+              echo "This command needs extra input. Run it directly: $picked"
+              continue
+              ;;
+          esac
+        fi
+        ;;
       /[a-zA-Z]* )
         # If not an exact command above, show prefix matches (e.g. /m, /mo).
         show_commands "$line"
@@ -899,6 +990,14 @@ main() {
     health) do_health ;;
     endpoint) show_endpoint ;;
     endpoint-check) check_endpoint ;;
+    menu)
+      picked="$(pick_command_interactive)"
+      if [[ -z "$picked" ]]; then
+        echo "No command selected."
+        exit 1
+      fi
+      echo "Selected: $(canonicalize_menu_choice "$picked")"
+      ;;
     run)
       shift || true
       if [[ -z "${*:-}" ]]; then

--- a/scripts/open-terminal
+++ b/scripts/open-terminal
@@ -5,6 +5,31 @@ SCRIPT_PATH="$(readlink -f "${BASH_SOURCE[0]}")"
 ROOT_DIR="$(cd "$(dirname "$SCRIPT_PATH")/.." && pwd)"
 VERIFY_SCRIPT="$ROOT_DIR/scripts/verify-decoupled-stack.sh"
 OWUI_BIN="${OWUI_BIN:-$HOME/.local/bin/owui}"
+OWUI_STATE_FILE="${XDG_CONFIG_HOME:-$HOME/.config}/open-webui-custom/model_profile.env"
+DEFAULT_ENDPOINT="http://127.0.0.1:8000/v1"
+CHAT_HISTORY_FILE="${XDG_STATE_HOME:-$HOME/.local/state}/open-terminal/chat_history.jsonl"
+mkdir -p "$(dirname "$CHAT_HISTORY_FILE")"
+
+COMMANDS=(
+  "/help"
+  "/q"
+  "/start"
+  "/stop"
+  "/restart"
+  "/status"
+  "/logs"
+  "/health"
+  "/verify"
+  "/model"
+  "/models"
+  "/model gemma"
+  "/model qwen"
+  "/model openvino"
+  "/model custom <url>"
+  "/endpoint"
+  "/clear"
+  "/quit"
+)
 
 usage() {
   cat <<'EOF'
@@ -18,6 +43,8 @@ Usage:
   open-terminal help
 
 Slash commands inside REPL:
+  /
+  /<prefix>           # filter commands, e.g. /m
   /start
   /stop
   /restart
@@ -27,6 +54,8 @@ Slash commands inside REPL:
   /verify
   /model
   /model gemma|qwen|openvino|custom <url>
+  /endpoint
+  /clear              # clear local chat history
   /help
   /quit
 EOF
@@ -39,6 +68,147 @@ do_status() { systemctl --user --no-pager status open-terminal; }
 do_logs() { journalctl --user -u open-terminal -n "${1:-120}" --no-pager; }
 do_health() { curl -fsS http://127.0.0.1:8010/health && echo; }
 do_verify() { "$VERIFY_SCRIPT"; }
+do_clear() {
+  : > "$CHAT_HISTORY_FILE"
+  echo "Chat history cleared."
+}
+
+current_endpoint() {
+  if [[ -f "$OWUI_STATE_FILE" ]]; then
+    # shellcheck disable=SC1090
+    source "$OWUI_STATE_FILE"
+    if [[ -n "${OWUI_ENDPOINT:-}" ]]; then
+      echo "$OWUI_ENDPOINT"
+      return
+    fi
+  fi
+  echo "$DEFAULT_ENDPOINT"
+}
+
+show_endpoint() {
+  echo "Current model endpoint: $(current_endpoint)"
+}
+
+show_commands() {
+  local prefix="${1:-/}"
+  local shown=0
+  local normalized="${prefix#/}"
+  local cmd
+
+  # First pass: strict prefix matching
+  for cmd in "${COMMANDS[@]}"; do
+    if [[ "$cmd" == "$prefix"* ]]; then
+      echo "  $cmd"
+      shown=1
+    fi
+  done
+
+  # Second pass: substring matching (copilot-style discoverability)
+  if [[ "$shown" -eq 0 && -n "$normalized" ]]; then
+    for cmd in "${COMMANDS[@]}"; do
+      if [[ "${cmd#/}" == *"$normalized"* ]]; then
+        echo "  $cmd"
+        shown=1
+      fi
+    done
+  fi
+
+  if [[ "$shown" -eq 0 ]]; then
+    echo "No slash commands match: $prefix"
+    echo "Tip: type / to list commands."
+  fi
+}
+
+current_model_id() {
+  local endpoint models_url id
+  endpoint="$(current_endpoint)"
+  models_url="${endpoint%/}/models"
+  id="$(curl -fsS "$models_url" 2>/dev/null | python3 - <<'PY'
+import json,sys
+try:
+    data=json.load(sys.stdin)
+    items=data.get("data") or []
+    if items and isinstance(items, list):
+        first=items[0]
+        if isinstance(first, dict) and first.get("id"):
+            print(first["id"])
+except Exception:
+    pass
+PY
+)"
+  if [[ -n "$id" ]]; then
+    echo "$id"
+  else
+    echo "default"
+  fi
+}
+
+chat_send() {
+  local user_text="$1"
+  local endpoint chat_url model payload resp assistant
+  endpoint="$(current_endpoint)"
+  chat_url="${endpoint%/}/chat/completions"
+  model="$(current_model_id)"
+
+  payload="$(python3 - "$CHAT_HISTORY_FILE" "$model" "$user_text" <<'PY'
+import json,sys
+hist_path,model,user_text=sys.argv[1],sys.argv[2],sys.argv[3]
+msgs=[]
+try:
+    with open(hist_path,"r",encoding="utf-8") as f:
+        for line in f:
+            line=line.strip()
+            if not line:
+                continue
+            obj=json.loads(line)
+            if isinstance(obj,dict) and obj.get("role") in {"user","assistant","system"}:
+                msgs.append({"role":obj["role"],"content":str(obj.get("content",""))})
+except FileNotFoundError:
+    pass
+msgs.append({"role":"user","content":user_text})
+print(json.dumps({"model":model,"messages":msgs,"temperature":0.2}, ensure_ascii=False))
+PY
+)"
+
+  resp="$(curl -fsS \
+    -H 'Content-Type: application/json' \
+    -H 'Authorization: Bearer dummy' \
+    -d "$payload" \
+    "$chat_url" 2>&1)" || {
+      echo "Chat request failed against $chat_url"
+      echo "$resp"
+      echo "Tip: run /model and select a profile with a live endpoint."
+      return 1
+    }
+
+  assistant="$(python3 - <<'PY' "$resp"
+import json,sys
+raw=sys.argv[1]
+try:
+    data=json.loads(raw)
+except Exception:
+    print("")
+    raise SystemExit(0)
+msg=((data.get("choices") or [{}])[0].get("message") or {}).get("content","")
+if isinstance(msg,list):
+    parts=[]
+    for item in msg:
+        if isinstance(item,dict) and item.get("type")=="text":
+            parts.append(str(item.get("text","")))
+    msg="\n".join([p for p in parts if p])
+print(msg if isinstance(msg,str) else str(msg))
+PY
+)"
+
+  if [[ -z "$assistant" ]]; then
+    echo "No assistant content returned."
+    return 1
+  fi
+
+  printf '{"role":"user","content":%s}\n' "$(python3 -c 'import json,sys; print(json.dumps(sys.argv[1]))' "$user_text")" >> "$CHAT_HISTORY_FILE"
+  printf '{"role":"assistant","content":%s}\n' "$(python3 -c 'import json,sys; print(json.dumps(sys.argv[1]))' "$assistant")" >> "$CHAT_HISTORY_FILE"
+  echo "$assistant"
+}
 
 do_model() {
   if [[ ! -x "$OWUI_BIN" ]]; then
@@ -54,7 +224,7 @@ do_model() {
 }
 
 run_repl() {
-  echo "open-terminal REPL. Type /help for commands. Press Ctrl+C to exit."
+  echo "open-terminal chat REPL. Type text to chat. Type / for commands. Press Ctrl+C to exit."
   trap 'echo; echo "Exiting open-terminal REPL."; exit 0' INT
 
   while true; do
@@ -62,7 +232,7 @@ run_repl() {
     case "$line" in
       "" ) continue ;;
       "/help" ) usage ;;
-      "/quit"|"/exit" ) break ;;
+      "/quit"|"/exit"|"/q" ) break ;;
       "/start" ) do_start ;;
       "/stop" ) do_stop ;;
       "/restart" ) do_restart ;;
@@ -70,7 +240,10 @@ run_repl() {
       "/logs" ) do_logs ;;
       "/health" ) do_health || echo "Health check failed." ;;
       "/verify" ) do_verify || true ;;
+      "/endpoint" ) show_endpoint ;;
+      "/clear" ) do_clear ;;
       "/model" ) do_model || true ;;
+      "/models" ) do_model || true ;;
       /model\ gemma ) do_model gemma ;;
       /model\ qwen ) do_model qwen ;;
       /model\ openvino ) do_model openvino ;;
@@ -85,7 +258,14 @@ run_repl() {
       /model* )
         echo "Usage: /model | /model gemma|qwen|openvino|custom <url>"
         ;;
-      * ) echo "Unknown command: $line" ;;
+      "/" ) show_commands "/" ;;
+      /[a-zA-Z]* )
+        # If not an exact command above, show prefix matches (e.g. /m, /mo).
+        show_commands "$line"
+        ;;
+      * )
+        chat_send "$line" || true
+        ;;
     esac
   done
 }

--- a/scripts/open-terminal
+++ b/scripts/open-terminal
@@ -11,6 +11,8 @@ CHAT_HISTORY_FILE="${XDG_STATE_HOME:-$HOME/.local/state}/open-terminal/chat_hist
 MODEL_ACTIVATE_SCRIPT="${MODEL_ACTIVATE_SCRIPT:-/home/trotsky/Projects/b70-linux-ai-lab/scripts/z490_local_model_activate.sh}"
 WAIT_TIMEOUT_SECONDS="${WAIT_TIMEOUT_SECONDS:-120}"
 OT_AUTO_RETURN_TO_GEMMA=0
+OT_CHAT_MODE="${OT_CHAT_MODE:-chat}"
+OT_LAST_PAYLOAD=""
 mkdir -p "$(dirname "$CHAT_HISTORY_FILE")"
 
 COMMANDS=(
@@ -34,6 +36,11 @@ COMMANDS=(
   "/model custom <url>"
   "/endpoint"
   "/endpoint-check"
+  "/mode"
+  "/mode chat"
+  "/mode raw"
+  "/raw <prompt>"
+  "/diag prompt"
   "/clear"
   "/quit"
 )
@@ -68,6 +75,9 @@ Slash commands inside REPL:
   /model text|vision|gemma|qwen|qwen-temp|openvino|custom <url>
   /endpoint
   /endpoint-check
+  /mode [chat|raw]
+  /raw <prompt>        # send one prompt in raw mode (no history, temp=0)
+  /diag prompt [text]  # print exact outgoing payload (uses text if provided)
   /clear              # clear local chat history
   /help
   /quit
@@ -228,14 +238,20 @@ PY
   fi
 }
 
-chat_send() {
-  local user_text="$1"
-  local endpoint chat_url model payload resp assistant
-  endpoint="$(current_endpoint)"
-  chat_url="${endpoint%/}/chat/completions"
-  model="$(current_model_id)"
-
-  payload="$(python3 - "$CHAT_HISTORY_FILE" "$model" "$user_text" <<'PY'
+build_payload() {
+  local mode="$1"
+  local user_text="$2"
+  local model="$3"
+  local payload=""
+  if [[ "$mode" == "raw" ]]; then
+    payload="$(python3 - "$model" "$user_text" <<'PY'
+import json,sys
+model,user_text=sys.argv[1],sys.argv[2]
+print(json.dumps({"model":model,"messages":[{"role":"user","content":user_text}],"temperature":0}, ensure_ascii=False))
+PY
+)"
+  else
+    payload="$(python3 - "$CHAT_HISTORY_FILE" "$model" "$user_text" <<'PY'
 import json,sys
 hist_path,model,user_text=sys.argv[1],sys.argv[2],sys.argv[3]
 msgs=[]
@@ -254,19 +270,13 @@ msgs.append({"role":"user","content":user_text})
 print(json.dumps({"model":model,"messages":msgs,"temperature":0.2}, ensure_ascii=False))
 PY
 )"
+  fi
+  echo "$payload"
+}
 
-  resp="$(curl -fsS \
-    -H 'Content-Type: application/json' \
-    -H 'Authorization: Bearer dummy' \
-    -d "$payload" \
-    "$chat_url" 2>&1)" || {
-      echo "Chat request failed against $chat_url"
-      echo "$resp"
-      echo "Tip: run /model and select a profile with a live endpoint."
-      return 1
-    }
-
-  assistant="$(python3 - <<'PY' "$resp"
+extract_assistant_text() {
+  local raw="$1"
+  python3 - <<'PY' "$raw"
 import json,sys
 raw=sys.argv[1]
 try:
@@ -283,15 +293,42 @@ if isinstance(msg,list):
     msg="\n".join([p for p in parts if p])
 print(msg if isinstance(msg,str) else str(msg))
 PY
-)"
+}
+
+chat_send() {
+  local user_text="$1"
+  local force_mode="${2:-}"
+  local endpoint chat_url model payload resp assistant mode
+  endpoint="$(current_endpoint)"
+  chat_url="${endpoint%/}/chat/completions"
+  model="$(current_model_id)"
+  mode="${force_mode:-$OT_CHAT_MODE}"
+
+  payload="$(build_payload "$mode" "$user_text" "$model")"
+  OT_LAST_PAYLOAD="$payload"
+
+  resp="$(curl -fsS \
+    -H 'Content-Type: application/json' \
+    -H 'Authorization: Bearer dummy' \
+    -d "$payload" \
+    "$chat_url" 2>&1)" || {
+      echo "Chat request failed against $chat_url"
+      echo "$resp"
+      echo "Tip: run /model and select a profile with a live endpoint."
+      return 1
+    }
+
+  assistant="$(extract_assistant_text "$resp")"
 
   if [[ -z "$assistant" ]]; then
     echo "No assistant content returned."
     return 1
   fi
 
-  printf '{"role":"user","content":%s}\n' "$(python3 -c 'import json,sys; print(json.dumps(sys.argv[1]))' "$user_text")" >> "$CHAT_HISTORY_FILE"
-  printf '{"role":"assistant","content":%s}\n' "$(python3 -c 'import json,sys; print(json.dumps(sys.argv[1]))' "$assistant")" >> "$CHAT_HISTORY_FILE"
+  if [[ "$mode" == "chat" ]]; then
+    printf '{"role":"user","content":%s}\n' "$(python3 -c 'import json,sys; print(json.dumps(sys.argv[1]))' "$user_text")" >> "$CHAT_HISTORY_FILE"
+    printf '{"role":"assistant","content":%s}\n' "$(python3 -c 'import json,sys; print(json.dumps(sys.argv[1]))' "$assistant")" >> "$CHAT_HISTORY_FILE"
+  fi
   echo "$assistant"
   if [[ "$OT_AUTO_RETURN_TO_GEMMA" -eq 1 ]]; then
     OT_AUTO_RETURN_TO_GEMMA=0
@@ -299,6 +336,28 @@ PY
     echo "Auto-returning to Gemma primary..."
     do_model gemma || true
   fi
+}
+
+do_mode() {
+  local target="${1:-}"
+  if [[ -z "$target" ]]; then
+    echo "Current mode: $OT_CHAT_MODE"
+    return 0
+  fi
+  case "$target" in
+    chat|raw) OT_CHAT_MODE="$target"; echo "Mode set to: $OT_CHAT_MODE" ;;
+    *) echo "Usage: /mode [chat|raw]"; return 1 ;;
+  esac
+}
+
+do_diag_prompt() {
+  local text="${1:-diagnostic-ping}"
+  local mode="${2:-$OT_CHAT_MODE}"
+  local model payload
+  model="$(current_model_id)"
+  payload="$(build_payload "$mode" "$text" "$model")"
+  OT_LAST_PAYLOAD="$payload"
+  echo "$payload"
 }
 
 do_model() {
@@ -380,6 +439,10 @@ run_repl() {
       "/endpoint-check" ) check_endpoint ;;
       "/verify" ) do_verify || true ;;
       "/clear" ) do_clear ;;
+      "/mode" ) do_mode ;;
+      /mode\ chat ) do_mode chat ;;
+      /mode\ raw ) do_mode raw ;;
+      "/diag prompt" ) do_diag_prompt ;;
       "/model" ) do_model || true ;;
       "/models" ) do_model || true ;;
       /model\ text ) do_model text ;;
@@ -398,6 +461,21 @@ run_repl() {
         ;;
       /model* )
         echo "Usage: /model | /model text|vision|gemma|qwen|qwen-temp|openvino|custom <url>"
+        ;;
+      /raw\ * )
+        raw_text="${line#"/raw "}"
+        if [[ -z "$raw_text" || "$raw_text" == "/raw " ]]; then
+          echo "Usage: /raw <prompt>"
+        else
+          chat_send "$raw_text" raw || true
+        fi
+        ;;
+      /diag\ prompt\ * )
+        diag_text="${line#"/diag prompt "}"
+        do_diag_prompt "$diag_text"
+        ;;
+      /mode* )
+        echo "Usage: /mode [chat|raw]"
         ;;
       "/" ) show_commands "/" ;;
       /[a-zA-Z]* )
@@ -423,6 +501,22 @@ main() {
     health) do_health ;;
     endpoint) show_endpoint ;;
     endpoint-check) check_endpoint ;;
+    mode)
+      shift || true
+      do_mode "${1:-}"
+      ;;
+    raw)
+      shift || true
+      if [[ -z "${*:-}" ]]; then
+        echo "Usage: open-terminal raw <prompt>"
+        exit 1
+      fi
+      chat_send "${*}" raw
+      ;;
+    diag-prompt)
+      shift || true
+      do_diag_prompt "${1:-}"
+      ;;
     verify) do_verify ;;
     model)
       shift || true

--- a/scripts/open-terminal
+++ b/scripts/open-terminal
@@ -27,9 +27,14 @@ COMMANDS=(
   "/model openvino"
   "/model custom <url>"
   "/endpoint"
+  "/endpoint-check"
   "/clear"
   "/quit"
 )
+
+OT_TAB_LAST_PREFIX=""
+OT_TAB_INDEX=0
+OT_TAB_MATCHES=()
 
 usage() {
   cat <<'EOF'
@@ -45,6 +50,7 @@ Usage:
 Slash commands inside REPL:
   /
   /<prefix>           # filter commands, e.g. /m
+  TAB                 # cycle matching slash commands
   /start
   /stop
   /restart
@@ -55,6 +61,7 @@ Slash commands inside REPL:
   /model
   /model gemma|qwen|openvino|custom <url>
   /endpoint
+  /endpoint-check
   /clear              # clear local chat history
   /help
   /quit
@@ -116,6 +123,58 @@ show_commands() {
   if [[ "$shown" -eq 0 ]]; then
     echo "No slash commands match: $prefix"
     echo "Tip: type / to list commands."
+  fi
+}
+
+build_command_matches() {
+  local prefix="$1"
+  local normalized="${prefix#/}"
+  local cmd
+  OT_TAB_MATCHES=()
+
+  for cmd in "${COMMANDS[@]}"; do
+    if [[ "$cmd" == "$prefix"* ]]; then
+      OT_TAB_MATCHES+=("$cmd")
+    fi
+  done
+
+  if [[ "${#OT_TAB_MATCHES[@]}" -eq 0 && -n "$normalized" ]]; then
+    for cmd in "${COMMANDS[@]}"; do
+      if [[ "${cmd#/}" == *"$normalized"* ]]; then
+        OT_TAB_MATCHES+=("$cmd")
+      fi
+    done
+  fi
+}
+
+slash_tab_complete() {
+  # readline callback; uses READLINE_LINE / READLINE_POINT
+  local prefix
+  prefix="${READLINE_LINE:-}"
+  if [[ "$prefix" != /* ]]; then
+    return
+  fi
+
+  if [[ "$prefix" != "$OT_TAB_LAST_PREFIX" ]]; then
+    build_command_matches "$prefix"
+    OT_TAB_INDEX=0
+    OT_TAB_LAST_PREFIX="$prefix"
+  else
+    if [[ "${#OT_TAB_MATCHES[@]}" -gt 0 ]]; then
+      OT_TAB_INDEX=$(( (OT_TAB_INDEX + 1) % ${#OT_TAB_MATCHES[@]} ))
+    fi
+  fi
+
+  if [[ "${#OT_TAB_MATCHES[@]}" -gt 0 ]]; then
+    READLINE_LINE="${OT_TAB_MATCHES[$OT_TAB_INDEX]}"
+    READLINE_POINT=${#READLINE_LINE}
+  fi
+}
+
+setup_readline_bindings() {
+  # Bind TAB (Ctrl+I) to slash command completion cycling.
+  if [[ -t 0 && -t 1 ]]; then
+    bind -x '"\C-i":slash_tab_complete'
   fi
 }
 
@@ -223,12 +282,26 @@ do_model() {
   fi
 }
 
+check_endpoint() {
+  local endpoint models_url
+  endpoint="$(current_endpoint)"
+  models_url="${endpoint%/}/models"
+  echo "Endpoint: $endpoint"
+  if curl -fsS "$models_url" >/dev/null 2>&1; then
+    echo "Endpoint status: reachable"
+  else
+    echo "Endpoint status: unreachable"
+    echo "Remediation: start the model backend serving $endpoint or switch profile via /model."
+  fi
+}
+
 run_repl() {
   echo "open-terminal chat REPL. Type text to chat. Type / for commands. Press Ctrl+C to exit."
   trap 'echo; echo "Exiting open-terminal REPL."; exit 0' INT
+  setup_readline_bindings
 
   while true; do
-    read -rp "open-terminal> " line || break
+    read -e -rp "open-terminal> " line || break
     case "$line" in
       "" ) continue ;;
       "/help" ) usage ;;
@@ -239,8 +312,9 @@ run_repl() {
       "/status" ) do_status ;;
       "/logs" ) do_logs ;;
       "/health" ) do_health || echo "Health check failed." ;;
-      "/verify" ) do_verify || true ;;
       "/endpoint" ) show_endpoint ;;
+      "/endpoint-check" ) check_endpoint ;;
+      "/verify" ) do_verify || true ;;
       "/clear" ) do_clear ;;
       "/model" ) do_model || true ;;
       "/models" ) do_model || true ;;
@@ -280,6 +354,8 @@ main() {
     status) do_status ;;
     logs) do_logs "${2:-120}" ;;
     health) do_health ;;
+    endpoint) show_endpoint ;;
+    endpoint-check) check_endpoint ;;
     verify) do_verify ;;
     model)
       shift || true

--- a/scripts/open-terminal
+++ b/scripts/open-terminal
@@ -104,6 +104,7 @@ Slash commands inside REPL:
   /menu                # interactive command picker
   /<prefix>           # filter commands, e.g. /m
   TAB                 # cycle matching slash commands
+  Ctrl+C              # exit REPL
   /start
   /stop
   /restart
@@ -136,6 +137,53 @@ Slash commands inside REPL:
   /help
   /quit
 EOF
+}
+
+command_description() {
+  local cmd="$1"
+  case "$cmd" in
+    "/help") echo "Show CLI and slash-command help." ;;
+    "/menu") echo "Open interactive slash-command picker." ;;
+    "/q"|"/quit"|"/exit") echo "Exit REPL." ;;
+    "/start") echo "Start open-terminal systemd user service." ;;
+    "/stop") echo "Stop open-terminal systemd user service." ;;
+    "/restart") echo "Restart open-terminal systemd user service." ;;
+    "/status") echo "Show systemd service status." ;;
+    "/logs") echo "Show recent service logs." ;;
+    "/health") echo "Run local health check." ;;
+    "/verify") echo "Run decoupled stack verification script." ;;
+    "/model"|"/models") echo "Show/select model profile." ;;
+    "/model text"|"/model gemma") echo "Switch to Gemma text profile." ;;
+    "/model vision"|"/model openvino") echo "Switch to OpenVINO/vision profile." ;;
+    "/model qwen (on-demand warm-up)"|"/model qwen") echo "Switch to Qwen with on-demand warm-up." ;;
+    "/model qwen-temp (one reply, then auto-return to gemma)"|"/model qwen-temp") echo "One-reply Qwen session, then auto-return to Gemma." ;;
+    "/model custom <url>") echo "Set custom endpoint URL profile." ;;
+    "/endpoint") echo "Show current active endpoint URL." ;;
+    "/endpoint-check") echo "Check endpoint reachability." ;;
+    "/mode") echo "Show current chat mode." ;;
+    "/mode chat") echo "Use history-aware chat mode." ;;
+    "/mode raw") echo "Use stateless raw mode." ;;
+    "/raw <prompt>") echo "Send one stateless prompt." ;;
+    "/diag prompt") echo "Show outgoing payload preview." ;;
+    "/history") echo "Show session history lines." ;;
+    "/resume --all") echo "List all saved sessions." ;;
+    "/session list") echo "List sessions." ;;
+    "/session new [name]") echo "Create a new session." ;;
+    "/session use <id>") echo "Switch to an existing session." ;;
+    "/clear") echo "Clear active session history file." ;;
+    "/run <task>") echo "Start async codex-gemma worker job." ;;
+    "/jobs") echo "List async jobs." ;;
+    "/job status <job_id>") echo "Show job metadata and state." ;;
+    "/job wait <job_id>") echo "Wait for job completion." ;;
+    "/job result <job_id>") echo "Print job result output." ;;
+    "/job logs <job_id>") echo "Tail/read job log output." ;;
+    "/job cancel <job_id>") echo "Cancel async job via systemd unit." ;;
+    "/contract") echo "Show strict contract mode status." ;;
+    "/contract strict|off") echo "Enable/disable strict output validation." ;;
+    "/statusline") echo "Show status-line setting." ;;
+    "/statusline on|off") echo "Enable/disable prompt status line." ;;
+    *) echo "Slash command." ;;
+  esac
 }
 
 do_start() { systemctl --user start open-terminal; }
@@ -318,7 +366,7 @@ show_commands() {
   # First pass: strict prefix matching
   for cmd in "${COMMANDS[@]}"; do
     if [[ "$cmd" == "$prefix"* ]]; then
-      echo "  $cmd"
+      printf '  %-48s %s\n' "$cmd" "$(command_description "$cmd")"
       shown=1
     fi
   done
@@ -327,7 +375,7 @@ show_commands() {
   if [[ "$shown" -eq 0 && -n "$normalized" ]]; then
     for cmd in "${COMMANDS[@]}"; do
       if [[ "${cmd#/}" == *"$normalized"* ]]; then
-        echo "  $cmd"
+        printf '  %-48s %s\n' "$cmd" "$(command_description "$cmd")"
         shown=1
       fi
     done
@@ -341,14 +389,20 @@ show_commands() {
 
 pick_command_interactive() {
   local selection=""
+  local line
   if command -v fzf >/dev/null 2>&1; then
-    selection="$(printf '%s\n' "${COMMANDS[@]}" | fzf --prompt='slash> ' --height=40% --layout=reverse --border || true)"
+    selection="$(
+      for cmd in "${COMMANDS[@]}"; do
+        printf '%s\t%s\n' "$cmd" "$(command_description "$cmd")"
+      done | fzf --prompt='slash> ' --height=50% --layout=reverse --border --with-nth=1,2 --delimiter=$'\t' --preview 'echo {2}' --preview-window=down:3:wrap || true
+    )"
+    selection="${selection%%$'\t'*}"
   else
     echo "Interactive menu (fzf not installed, using numbered picker):" >&2
     local i=1
     local cmd
     for cmd in "${COMMANDS[@]}"; do
-      printf '%2d) %s\n' "$i" "$cmd" >&2
+      printf '%2d) %-48s %s\n' "$i" "$cmd" "$(command_description "$cmd")" >&2
       i=$((i + 1))
     done
     read -r -p "Choice [1-$((i-1))]: " choice >&2
@@ -834,7 +888,8 @@ check_endpoint() {
 }
 
 run_repl() {
-  echo "open-terminal chat REPL. Type text to chat. Type / for commands. Press Ctrl+C to exit."
+  echo "open-terminal chat REPL."
+  echo "Hints: type '/' for interactive menu, '/<prefix>' to filter, TAB to complete, Ctrl+C to exit."
   trap 'echo; echo "Exiting open-terminal REPL."; exit 0' INT
   setup_readline_bindings
 

--- a/scripts/open-terminal
+++ b/scripts/open-terminal
@@ -7,13 +7,19 @@ VERIFY_SCRIPT="$ROOT_DIR/scripts/verify-decoupled-stack.sh"
 OWUI_BIN="${OWUI_BIN:-$HOME/.local/bin/owui}"
 OWUI_STATE_FILE="${XDG_CONFIG_HOME:-$HOME/.config}/open-webui-custom/model_profile.env"
 DEFAULT_ENDPOINT="http://127.0.0.1:8000/v1"
-CHAT_HISTORY_FILE="${XDG_STATE_HOME:-$HOME/.local/state}/open-terminal/chat_history.jsonl"
+OT_STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/open-terminal"
+OT_CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/open-terminal"
+OT_SESSIONS_DIR="$OT_STATE_DIR/sessions"
+OT_ACTIVE_SESSION_FILE="$OT_STATE_DIR/active_session"
+OT_MODE_STATE_FILE="$OT_CONFIG_DIR/mode.env"
+CHAT_HISTORY_FILE="$OT_STATE_DIR/chat_history.jsonl"
 MODEL_ACTIVATE_SCRIPT="${MODEL_ACTIVATE_SCRIPT:-/home/trotsky/Projects/b70-linux-ai-lab/scripts/z490_local_model_activate.sh}"
 WAIT_TIMEOUT_SECONDS="${WAIT_TIMEOUT_SECONDS:-120}"
 OT_AUTO_RETURN_TO_GEMMA=0
 OT_CHAT_MODE="${OT_CHAT_MODE:-chat}"
 OT_LAST_PAYLOAD=""
-mkdir -p "$(dirname "$CHAT_HISTORY_FILE")"
+OT_CURRENT_SESSION_ID=""
+mkdir -p "$OT_STATE_DIR" "$OT_CONFIG_DIR" "$OT_SESSIONS_DIR"
 
 COMMANDS=(
   "/help"
@@ -41,6 +47,11 @@ COMMANDS=(
   "/mode raw"
   "/raw <prompt>"
   "/diag prompt"
+  "/history"
+  "/resume --all"
+  "/session list"
+  "/session new [name]"
+  "/session use <id>"
   "/clear"
   "/quit"
 )
@@ -58,6 +69,12 @@ Usage:
   open-terminal repl
   open-terminal start|stop|restart|status|logs|health|verify
   open-terminal model [profile]
+  open-terminal mode [chat|raw]
+  open-terminal raw "<prompt>"
+  open-terminal diag-prompt [text]
+  open-terminal history [N]
+  open-terminal resume --all
+  open-terminal session list|new [name]|use <id>
   open-terminal help
 
 Slash commands inside REPL:
@@ -78,6 +95,11 @@ Slash commands inside REPL:
   /mode [chat|raw]
   /raw <prompt>        # send one prompt in raw mode (no history, temp=0)
   /diag prompt [text]  # print exact outgoing payload (uses text if provided)
+  /history [N]         # show recent lines in current session history
+  /resume --all        # list all sessions
+  /session list
+  /session new [name]
+  /session use <id>
   /clear              # clear local chat history
   /help
   /quit
@@ -94,6 +116,106 @@ do_verify() { "$VERIFY_SCRIPT"; }
 do_clear() {
   : > "$CHAT_HISTORY_FILE"
   echo "Chat history cleared."
+}
+
+slugify_name() {
+  local raw="${1:-}"
+  raw="$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9' '-')"
+  raw="${raw#-}"
+  raw="${raw%-}"
+  echo "${raw:-session}"
+}
+
+session_set_active() {
+  local id="$1"
+  OT_CURRENT_SESSION_ID="$id"
+  CHAT_HISTORY_FILE="$OT_SESSIONS_DIR/${id}.jsonl"
+  printf '%s\n' "$id" > "$OT_ACTIVE_SESSION_FILE"
+  touch "$CHAT_HISTORY_FILE"
+}
+
+session_new() {
+  local name="${1:-}"
+  local stamp id
+  stamp="$(date +%Y%m%d-%H%M%S)"
+  if [[ -n "$name" ]]; then
+    id="${stamp}-$(slugify_name "$name")"
+  else
+    id="$stamp"
+  fi
+  session_set_active "$id"
+  echo "Started session: $OT_CURRENT_SESSION_ID"
+}
+
+session_list() {
+  local file id lines
+  shopt -s nullglob
+  for file in "$OT_SESSIONS_DIR"/*.jsonl; do
+    id="$(basename "$file" .jsonl)"
+    lines="$(wc -l < "$file" | tr -d ' ')"
+    if [[ "$id" == "$OT_CURRENT_SESSION_ID" ]]; then
+      echo "* $id (lines=$lines)"
+    else
+      echo "  $id (lines=$lines)"
+    fi
+  done
+  shopt -u nullglob
+}
+
+session_use() {
+  local id="${1:-}"
+  if [[ -z "$id" ]]; then
+    echo "Usage: /session use <id>"
+    return 1
+  fi
+  if [[ ! -f "$OT_SESSIONS_DIR/${id}.jsonl" ]]; then
+    echo "Session not found: $id"
+    return 1
+  fi
+  session_set_active "$id"
+  echo "Switched to session: $OT_CURRENT_SESSION_ID"
+}
+
+history_show() {
+  local n="${1:-40}"
+  if [[ ! "$n" =~ ^[0-9]+$ ]]; then
+    echo "Usage: /history [N]"
+    return 1
+  fi
+  echo "Session: $OT_CURRENT_SESSION_ID"
+  tail -n "$n" "$CHAT_HISTORY_FILE" 2>/dev/null || true
+}
+
+resume_all() {
+  echo "All sessions:"
+  session_list
+}
+
+load_mode_state() {
+  if [[ -f "$OT_MODE_STATE_FILE" ]]; then
+    # shellcheck disable=SC1090
+    source "$OT_MODE_STATE_FILE"
+    if [[ "${OT_SAVED_MODE:-}" == "chat" || "${OT_SAVED_MODE:-}" == "raw" ]]; then
+      OT_CHAT_MODE="$OT_SAVED_MODE"
+    fi
+  fi
+}
+
+save_mode_state() {
+  printf 'OT_SAVED_MODE=%s\n' "$OT_CHAT_MODE" > "$OT_MODE_STATE_FILE"
+}
+
+init_state() {
+  load_mode_state
+  if [[ -f "$OT_ACTIVE_SESSION_FILE" ]]; then
+    local last
+    last="$(cat "$OT_ACTIVE_SESSION_FILE" 2>/dev/null || true)"
+    if [[ -n "$last" && -f "$OT_SESSIONS_DIR/${last}.jsonl" ]]; then
+      session_set_active "$last"
+      return
+    fi
+  fi
+  session_new "default" >/dev/null
 }
 
 wait_for_models_endpoint() {
@@ -345,7 +467,11 @@ do_mode() {
     return 0
   fi
   case "$target" in
-    chat|raw) OT_CHAT_MODE="$target"; echo "Mode set to: $OT_CHAT_MODE" ;;
+    chat|raw)
+      OT_CHAT_MODE="$target"
+      save_mode_state
+      echo "Mode set to: $OT_CHAT_MODE"
+      ;;
     *) echo "Usage: /mode [chat|raw]"; return 1 ;;
   esac
 }
@@ -439,6 +565,13 @@ run_repl() {
       "/endpoint-check" ) check_endpoint ;;
       "/verify" ) do_verify || true ;;
       "/clear" ) do_clear ;;
+      "/history" ) history_show ;;
+      /history\ * ) history_show "${line#"/history "}" ;;
+      "/resume --all" ) resume_all ;;
+      "/session list" ) session_list ;;
+      "/session new" ) session_new ;;
+      /session\ new\ * ) session_new "${line#"/session new "}" ;;
+      /session\ use\ * ) session_use "${line#"/session use "}" ;;
       "/mode" ) do_mode ;;
       /mode\ chat ) do_mode chat ;;
       /mode\ raw ) do_mode raw ;;
@@ -477,6 +610,9 @@ run_repl() {
       /mode* )
         echo "Usage: /mode [chat|raw]"
         ;;
+      /session* )
+        echo "Usage: /session list | /session new [name] | /session use <id>"
+        ;;
       "/" ) show_commands "/" ;;
       /[a-zA-Z]* )
         # If not an exact command above, show prefix matches (e.g. /m, /mo).
@@ -490,6 +626,7 @@ run_repl() {
 }
 
 main() {
+  init_state
   cmd="${1:-repl}"
   case "$cmd" in
     repl) run_repl ;;
@@ -516,6 +653,28 @@ main() {
     diag-prompt)
       shift || true
       do_diag_prompt "${1:-}"
+      ;;
+    history)
+      shift || true
+      history_show "${1:-40}"
+      ;;
+    resume)
+      shift || true
+      if [[ "${1:-}" == "--all" ]]; then
+        resume_all
+      else
+        echo "Usage: open-terminal resume --all"
+        exit 1
+      fi
+      ;;
+    session)
+      shift || true
+      case "${1:-list}" in
+        list) session_list ;;
+        new) shift || true; session_new "${*:-}" ;;
+        use) shift || true; session_use "${1:-}" ;;
+        *) echo "Usage: open-terminal session list|new [name]|use <id>"; exit 1 ;;
+      esac
       ;;
     verify) do_verify ;;
     model)

--- a/scripts/open-terminal
+++ b/scripts/open-terminal
@@ -357,16 +357,64 @@ prompt_status() {
   printf 'open-terminal[%s|%s|%s]> ' "$OT_CHAT_MODE" "$model" "$short_cwd"
 }
 
+command_category() {
+  local cmd="$1"
+  case "$cmd" in
+    "/start"|"/stop"|"/restart"|"/status"|"/logs"|"/health"|"/verify"|"/endpoint"|"/endpoint-check")
+      echo "system"
+      ;;
+    "/model"|"/models"|"/model text"|"/model vision"|"/model gemma"|"/model qwen (on-demand warm-up)"|"/model qwen-temp (one reply, then auto-return to gemma)"|"/model openvino"|"/model custom <url>")
+      echo "model"
+      ;;
+    "/session list"|"/session new [name]"|"/session use <id>"|"/history"|"/resume --all"|"/clear")
+      echo "session"
+      ;;
+    "/run <task>"|"/jobs"|"/job status <job_id>"|"/job wait <job_id>"|"/job result <job_id>"|"/job logs <job_id>"|"/job cancel <job_id>")
+      echo "jobs"
+      ;;
+    "/contract"|"/contract strict|off"|"/statusline"|"/statusline on|off")
+      echo "safety"
+      ;;
+    "/mode"|"/mode chat"|"/mode raw"|"/raw <prompt>"|"/diag prompt")
+      echo "chat"
+      ;;
+    "/help"|"/menu"|"/q"|"/quit"|"/exit")
+      echo "meta"
+      ;;
+    *)
+      echo "other"
+      ;;
+  esac
+}
+
+category_rank() {
+  local cat="$1"
+  case "$cat" in
+    meta) echo 1 ;;
+    system) echo 2 ;;
+    model) echo 3 ;;
+    chat) echo 4 ;;
+    session) echo 5 ;;
+    jobs) echo 6 ;;
+    safety) echo 7 ;;
+    *) echo 9 ;;
+  esac
+}
+
 show_commands() {
   local prefix="${1:-/}"
   local shown=0
   local normalized="${prefix#/}"
-  local cmd
+  local cmd cat rank
+  local tmp
+  tmp="$(mktemp)"
 
   # First pass: strict prefix matching
   for cmd in "${COMMANDS[@]}"; do
     if [[ "$cmd" == "$prefix"* ]]; then
-      printf '  %-48s %s\n' "$cmd" "$(command_description "$cmd")"
+      cat="$(command_category "$cmd")"
+      rank="$(category_rank "$cat")"
+      printf '%s\t%s\t%s\t%s\n' "$rank" "$cat" "$cmd" "$(command_description "$cmd")" >> "$tmp"
       shown=1
     fi
   done
@@ -375,41 +423,72 @@ show_commands() {
   if [[ "$shown" -eq 0 && -n "$normalized" ]]; then
     for cmd in "${COMMANDS[@]}"; do
       if [[ "${cmd#/}" == *"$normalized"* ]]; then
-        printf '  %-48s %s\n' "$cmd" "$(command_description "$cmd")"
+        cat="$(command_category "$cmd")"
+        rank="$(category_rank "$cat")"
+        printf '%s\t%s\t%s\t%s\n' "$rank" "$cat" "$cmd" "$(command_description "$cmd")" >> "$tmp"
         shown=1
       fi
     done
   fi
 
   if [[ "$shown" -eq 0 ]]; then
+    rm -f "$tmp"
     echo "No slash commands match: $prefix"
     echo "Tip: type / to list commands."
+    return
   fi
+
+  sort -t $'\t' -k1,1n -k3,3 "$tmp" | awk -F '\t' '
+    BEGIN { prev="" }
+    {
+      if ($2 != prev) {
+        if (prev != "") print ""
+        printf("[%s]\n", $2)
+        prev=$2
+      }
+      printf("  %-48s %s\n", $3, $4)
+    }
+  '
+  rm -f "$tmp"
 }
 
 pick_command_interactive() {
   local selection=""
-  local line
+  local cat rank
+  local tmp
+  tmp="$(mktemp)"
+  for cmd in "${COMMANDS[@]}"; do
+    cat="$(command_category "$cmd")"
+    rank="$(category_rank "$cat")"
+    printf '%s\t%s\t%s\t%s\n' "$rank" "$cat" "$cmd" "$(command_description "$cmd")" >> "$tmp"
+  done
+
   if command -v fzf >/dev/null 2>&1; then
     selection="$(
-      for cmd in "${COMMANDS[@]}"; do
-        printf '%s\t%s\n' "$cmd" "$(command_description "$cmd")"
-      done | fzf --prompt='slash> ' --height=50% --layout=reverse --border --with-nth=1,2 --delimiter=$'\t' --preview 'echo {2}' --preview-window=down:3:wrap || true
+      sort -t $'\t' -k1,1n -k3,3 "$tmp" | awk -F '\t' '{ printf("[%s]\t%s\t%s\n", $2, $3, $4) }' \
+      | fzf --prompt='slash> ' --height=55% --layout=reverse --border --with-nth=1,2,3 --delimiter=$'\t' --preview 'echo {3}' --preview-window=down:3:wrap || true
     )"
-    selection="${selection%%$'\t'*}"
+    selection="$(printf '%s' "$selection" | cut -f2)"
   else
     echo "Interactive menu (fzf not installed, using numbered picker):" >&2
     local i=1
-    local cmd
-    for cmd in "${COMMANDS[@]}"; do
-      printf '%2d) %-48s %s\n' "$i" "$cmd" "$(command_description "$cmd")" >&2
+    local prev_cat=""
+    while IFS=$'\t' read -r rank cat cmd desc; do
+      if [[ "$cat" != "$prev_cat" ]]; then
+        echo >&2
+        printf '[%s]\n' "$cat" >&2
+        prev_cat="$cat"
+      fi
+      printf '%2d) %-48s %s\n' "$i" "$cmd" "$desc" >&2
+      OT_TAB_MATCHES[$((i-1))]="$cmd"
       i=$((i + 1))
-    done
+    done < <(sort -t $'\t' -k1,1n -k3,3 "$tmp")
     read -r -p "Choice [1-$((i-1))]: " choice >&2
     if [[ "${choice:-}" =~ ^[0-9]+$ ]] && (( choice >= 1 && choice < i )); then
-      selection="${COMMANDS[$((choice-1))]}"
+      selection="${OT_TAB_MATCHES[$((choice-1))]}"
     fi
   fi
+  rm -f "$tmp"
   printf '%s' "$selection"
 }
 

--- a/scripts/open-terminal
+++ b/scripts/open-terminal
@@ -8,6 +8,7 @@ OWUI_BIN="${OWUI_BIN:-$HOME/.local/bin/owui}"
 OWUI_STATE_FILE="${XDG_CONFIG_HOME:-$HOME/.config}/open-webui-custom/model_profile.env"
 DEFAULT_ENDPOINT="http://127.0.0.1:8000/v1"
 CHAT_HISTORY_FILE="${XDG_STATE_HOME:-$HOME/.local/state}/open-terminal/chat_history.jsonl"
+MODEL_ACTIVATE_SCRIPT="${MODEL_ACTIVATE_SCRIPT:-/home/trotsky/Projects/b70-linux-ai-lab/scripts/z490_local_model_activate.sh}"
 mkdir -p "$(dirname "$CHAT_HISTORY_FILE")"
 
 COMMANDS=(
@@ -25,7 +26,7 @@ COMMANDS=(
   "/model text"
   "/model vision"
   "/model gemma"
-  "/model qwen"
+  "/model qwen (on-demand warm-up)"
   "/model openvino"
   "/model custom <url>"
   "/endpoint"
@@ -280,6 +281,24 @@ do_model() {
   if [[ $# -eq 0 ]]; then
     "$OWUI_BIN" model
   else
+    case "${1:-}" in
+      text|gemma)
+        if [[ -x "$MODEL_ACTIVATE_SCRIPT" ]]; then
+          echo "Ensuring Gemma is the only active heavy model..."
+          "$MODEL_ACTIVATE_SCRIPT" gemma
+        fi
+        ;;
+      qwen)
+        if [[ -x "$MODEL_ACTIVATE_SCRIPT" ]]; then
+          echo "Switching to Qwen on-demand (Gemma will be stopped first)."
+          echo "This usually takes around 30-90 seconds depending on load."
+          "$MODEL_ACTIVATE_SCRIPT" qwen
+        else
+          echo "Warning: activation script not found at $MODEL_ACTIVATE_SCRIPT"
+          echo "Proceeding without one-model guard."
+        fi
+        ;;
+    esac
     "$OWUI_BIN" model "$@"
   fi
 }

--- a/scripts/open-terminal
+++ b/scripts/open-terminal
@@ -86,7 +86,7 @@ Usage:
   open-terminal start|stop|restart|status|logs|health|verify
   open-terminal model [profile]
   open-terminal mode [chat|raw]
-  open-terminal menu
+  open-terminal menu [meta|system|model|chat|session|jobs|safety]
   open-terminal run "<task>"
   open-terminal jobs
   open-terminal job status|wait|result|logs|cancel <job_id>
@@ -102,6 +102,7 @@ Usage:
 Slash commands inside REPL:
   /
   /menu                # interactive command picker
+  /menu <category>     # picker filtered by category
   /<prefix>           # filter commands, e.g. /m
   TAB                 # cycle matching slash commands
   Ctrl+C              # exit REPL
@@ -453,15 +454,25 @@ show_commands() {
 }
 
 pick_command_interactive() {
+  local category_filter="${1:-}"
   local selection=""
   local cat rank
   local tmp
   tmp="$(mktemp)"
   for cmd in "${COMMANDS[@]}"; do
     cat="$(command_category "$cmd")"
+    if [[ -n "$category_filter" && "$cat" != "$category_filter" ]]; then
+      continue
+    fi
     rank="$(category_rank "$cat")"
     printf '%s\t%s\t%s\t%s\n' "$rank" "$cat" "$cmd" "$(command_description "$cmd")" >> "$tmp"
   done
+
+  if [[ ! -s "$tmp" ]]; then
+    rm -f "$tmp"
+    printf '%s' ""
+    return
+  fi
 
   if command -v fzf >/dev/null 2>&1; then
     selection="$(
@@ -490,6 +501,14 @@ pick_command_interactive() {
   fi
   rm -f "$tmp"
   printf '%s' "$selection"
+}
+
+is_valid_category() {
+  local cat="${1:-}"
+  case "$cat" in
+    meta|system|model|chat|session|jobs|safety) return 0 ;;
+    *) return 1 ;;
+  esac
 }
 
 canonicalize_menu_choice() {
@@ -995,6 +1014,30 @@ run_repl() {
           esac
         fi
         ;;
+      /menu\ * )
+        menu_cat="${line#"/menu "}"
+        if ! is_valid_category "$menu_cat"; then
+          echo "Invalid category: $menu_cat"
+          echo "Valid categories: meta, system, model, chat, session, jobs, safety"
+          continue
+        fi
+        picked="$(pick_command_interactive "$menu_cat")"
+        if [[ -z "$picked" ]]; then
+          echo "No command selected."
+        else
+          picked="$(canonicalize_menu_choice "$picked")"
+          echo "Selected: $picked"
+          case "$picked" in
+            "/start"|"/stop"|"/restart"|"/status"|"/logs"|"/health"|"/verify"|"/endpoint"|"/endpoint-check"|"/model"|"/models"|"/mode"|"/history"|"/resume --all"|"/session list"|"/session new"|"/jobs"|"/contract"|"/statusline"|"/help"|"/clear")
+              line="$picked"
+              ;;
+            *)
+              echo "This command needs extra input. Run it directly: $picked"
+              continue
+              ;;
+          esac
+        fi
+        ;;
       "/quit"|"/exit"|"/q" ) break ;;
       "/start" ) do_start ;;
       "/stop" ) do_stop ;;
@@ -1125,7 +1168,14 @@ main() {
     endpoint) show_endpoint ;;
     endpoint-check) check_endpoint ;;
     menu)
-      picked="$(pick_command_interactive)"
+      shift || true
+      menu_cat="${1:-}"
+      if [[ -n "$menu_cat" ]] && ! is_valid_category "$menu_cat"; then
+        echo "Invalid category: $menu_cat"
+        echo "Valid categories: meta, system, model, chat, session, jobs, safety"
+        exit 1
+      fi
+      picked="$(pick_command_interactive "$menu_cat")"
       if [[ -z "$picked" ]]; then
         echo "No command selected."
         exit 1

--- a/scripts/open-terminal
+++ b/scripts/open-terminal
@@ -86,6 +86,7 @@ COMMANDS=(
   "/q"
   "/start"
   "/stop"
+  "/stop <job_id|watcher|all-jobs>"
   "/restart"
   "/status"
   "/logs"
@@ -115,6 +116,7 @@ COMMANDS=(
   "/clear"
   "/run <task>"
   "/jobs"
+  "/ps"
   "/job status <job_id>"
   "/job wait <job_id>"
   "/job result <job_id>"
@@ -166,6 +168,7 @@ Slash commands inside REPL:
   Ctrl+C              # exit REPL
   /start
   /stop
+  /stop <job_id|watcher|all-jobs>
   /restart
   /status
   /logs
@@ -185,6 +188,7 @@ Slash commands inside REPL:
   /session use <id>
   /run <task>          # async orchestration job via codex-gemma
   /jobs
+  /ps                 # quick background process view
   /job status <job_id>
   /job wait <job_id>
   /job result <job_id>
@@ -206,6 +210,7 @@ command_description() {
     "/q"|"/quit"|"/exit") echo "Exit REPL." ;;
     "/start") echo "Start open-terminal systemd user service." ;;
     "/stop") echo "Stop open-terminal systemd user service." ;;
+    "/stop <job_id|watcher|all-jobs>") echo "Stop a background watcher or async job." ;;
     "/restart") echo "Restart open-terminal systemd user service." ;;
     "/status") echo "Show systemd service status." ;;
     "/logs") echo "Show recent service logs." ;;
@@ -232,6 +237,7 @@ command_description() {
     "/clear") echo "Clear active session history file." ;;
     "/run <task>") echo "Start async codex-gemma worker job." ;;
     "/jobs") echo "List async jobs." ;;
+    "/ps") echo "Show background jobs and watcher service status." ;;
     "/job status <job_id>") echo "Show job metadata and state." ;;
     "/job wait <job_id>") echo "Wait for job completion." ;;
     "/job result <job_id>") echo "Print job result output." ;;
@@ -916,6 +922,48 @@ do_jobs() {
   "$CODEX_GEMMA_BIN" jobs
 }
 
+do_ps() {
+  echo "[async-jobs]"
+  do_jobs || true
+  echo
+  echo "[watcher]"
+  if systemctl --user is-active --quiet midnight-dust-watcher.service; then
+    echo "midnight-dust-watcher.service: active"
+  else
+    echo "midnight-dust-watcher.service: inactive"
+  fi
+}
+
+do_stop_target() {
+  local target="${1:-}"
+  local meta unit
+  case "$target" in
+    watcher)
+      systemctl --user stop midnight-dust-watcher.service
+      echo "Stopped midnight-dust-watcher.service"
+      ;;
+    all-jobs)
+      if [[ ! -d "$CG_STATE_DIR/codex-gemma-jobs" ]]; then
+        echo "No async jobs directory found."
+        return 0
+      fi
+      local stopped=0
+      for meta in "$CG_STATE_DIR"/codex-gemma-jobs/*.meta; do
+        [[ -f "$meta" ]] || continue
+        unit="$(sed -n 's/^unit=//p' "$meta" | tail -n1)"
+        if [[ -n "$unit" ]]; then
+          systemctl --user stop "$unit" || true
+          stopped=$((stopped + 1))
+        fi
+      done
+      echo "Requested stop for $stopped async job unit(s)."
+      ;;
+    *)
+      do_job cancel "$target"
+      ;;
+  esac
+}
+
 do_job() {
   local sub="${1:-}"
   local job_id="${2:-}"
@@ -1108,6 +1156,14 @@ run_repl() {
       "/quit"|"/exit"|"/q" ) break ;;
       "/start" ) do_start ;;
       "/stop" ) do_stop ;;
+      /stop\ * )
+        stop_target="${line#"/stop "}"
+        if [[ -z "$stop_target" || "$stop_target" == "/stop " ]]; then
+          do_stop
+        else
+          do_stop_target "$stop_target" || true
+        fi
+        ;;
       "/restart" ) do_restart ;;
       "/status" ) do_status ;;
       "/logs" ) do_logs ;;
@@ -1131,6 +1187,7 @@ run_repl() {
       /session\ use\ * ) session_use "${line#"/session use "}" ;;
       /run\ * ) do_run "${line#"/run "}" ;;
       "/jobs" ) do_jobs ;;
+      "/ps" ) do_ps ;;
       /job\ status\ * ) do_job status "${line#"/job status "}" ;;
       /job\ wait\ * ) do_job wait "${line#"/job wait "}" ;;
       /job\ result\ * ) do_job result "${line#"/job result "}" ;;
@@ -1186,8 +1243,14 @@ run_repl() {
       /jobs* )
         echo "Usage: /jobs"
         ;;
+      /ps* )
+        echo "Usage: /ps"
+        ;;
       /job* )
         echo "Usage: /job status|wait|result|logs|cancel <job_id>"
+        ;;
+      /stop* )
+        echo "Usage: /stop | /stop <job_id|watcher|all-jobs>"
         ;;
       /session* )
         echo "Usage: /session list | /session new [name] | /session use <id>"

--- a/scripts/open-terminal
+++ b/scripts/open-terminal
@@ -22,6 +22,8 @@ COMMANDS=(
   "/verify"
   "/model"
   "/models"
+  "/model text"
+  "/model vision"
   "/model gemma"
   "/model qwen"
   "/model openvino"
@@ -59,7 +61,7 @@ Slash commands inside REPL:
   /health
   /verify
   /model
-  /model gemma|qwen|openvino|custom <url>
+  /model text|vision|gemma|qwen|openvino|custom <url>
   /endpoint
   /endpoint-check
   /clear              # clear local chat history
@@ -318,6 +320,8 @@ run_repl() {
       "/clear" ) do_clear ;;
       "/model" ) do_model || true ;;
       "/models" ) do_model || true ;;
+      /model\ text ) do_model text ;;
+      /model\ vision ) do_model vision ;;
       /model\ gemma ) do_model gemma ;;
       /model\ qwen ) do_model qwen ;;
       /model\ openvino ) do_model openvino ;;
@@ -330,7 +334,7 @@ run_repl() {
         fi
         ;;
       /model* )
-        echo "Usage: /model | /model gemma|qwen|openvino|custom <url>"
+        echo "Usage: /model | /model text|vision|gemma|qwen|openvino|custom <url>"
         ;;
       "/" ) show_commands "/" ;;
       /[a-zA-Z]* )

--- a/scripts/open-terminal
+++ b/scripts/open-terminal
@@ -164,7 +164,7 @@ Slash commands inside REPL:
   /menu                # interactive command picker
   /menu <category>     # picker filtered by category
   /<prefix>           # filter commands, e.g. /m
-  TAB                 # cycle matching slash commands
+  TAB                 # open filtered picker for /<prefix> (or cycle fallback)
   Ctrl+C              # exit REPL
   /start
   /stop
@@ -567,6 +567,41 @@ pick_command_interactive() {
   printf '%s' "$selection"
 }
 
+pick_command_by_prefix() {
+  local prefix="${1:-/}"
+  local selection=""
+  local tmp cmd cat rank
+  local normalized="${prefix#/}"
+  tmp="$(mktemp)"
+
+  for cmd in "${COMMANDS[@]}"; do
+    if [[ "$cmd" == "$prefix"* ]] || { [[ -n "$normalized" ]] && [[ "${cmd#/}" == *"$normalized"* ]]; }; then
+      cat="$(command_category "$cmd")"
+      rank="$(category_rank "$cat")"
+      printf '%s\t%s\t%s\t%s\n' "$rank" "$cat" "$cmd" "$(command_description "$cmd")" >> "$tmp"
+    fi
+  done
+
+  if [[ ! -s "$tmp" ]]; then
+    rm -f "$tmp"
+    printf '%s' ""
+    return
+  fi
+
+  if command -v fzf >/dev/null 2>&1; then
+    selection="$(
+      sort -t $'\t' -k1,1n -k3,3 "$tmp" | awk -F '\t' '{ printf("[%s]\t%s\t%s\n", $2, $3, $4) }' \
+      | fzf --prompt="slash(${prefix})> " --height=55% --layout=reverse --border --with-nth=1,2,3 --delimiter=$'\t' --preview 'echo {3}' --preview-window=down:3:wrap --query "$normalized" || true
+    )"
+    selection="$(printf '%s' "$selection" | cut -f2)"
+  else
+    show_commands "$prefix" >&2
+  fi
+
+  rm -f "$tmp"
+  printf '%s' "$selection"
+}
+
 is_valid_category() {
   local cat="${1:-}"
   case "$cat" in
@@ -608,6 +643,7 @@ build_command_matches() {
 slash_tab_complete() {
   # readline callback; uses READLINE_LINE / READLINE_POINT
   local prefix
+  local picked=""
   prefix="${READLINE_LINE:-}"
   if [[ "$prefix" != /* ]]; then
     return
@@ -617,16 +653,29 @@ slash_tab_complete() {
     build_command_matches "$prefix"
     OT_TAB_INDEX=0
     OT_TAB_LAST_PREFIX="$prefix"
-  else
-    if [[ "${#OT_TAB_MATCHES[@]}" -gt 0 ]]; then
-      OT_TAB_INDEX=$(( (OT_TAB_INDEX + 1) % ${#OT_TAB_MATCHES[@]} ))
-    fi
   fi
 
-  if [[ "${#OT_TAB_MATCHES[@]}" -gt 0 ]]; then
+  if [[ "${#OT_TAB_MATCHES[@]}" -eq 1 ]]; then
+    READLINE_LINE="${OT_TAB_MATCHES[0]}"
+    READLINE_POINT=${#READLINE_LINE}
+    return
+  fi
+
+  if [[ "${#OT_TAB_MATCHES[@]}" -gt 1 ]]; then
+    picked="$(pick_command_by_prefix "$prefix")"
+    if [[ -n "$picked" ]]; then
+      READLINE_LINE="$(canonicalize_menu_choice "$picked")"
+      READLINE_POINT=${#READLINE_LINE}
+      return
+    fi
+    # fallback cycle when no picker selection made
+    OT_TAB_INDEX=$(( (OT_TAB_INDEX + 1) % ${#OT_TAB_MATCHES[@]} ))
     READLINE_LINE="${OT_TAB_MATCHES[$OT_TAB_INDEX]}"
     READLINE_POINT=${#READLINE_LINE}
+    return
   fi
+
+  show_commands "$prefix"
 }
 
 setup_readline_bindings() {

--- a/scripts/open-terminal
+++ b/scripts/open-terminal
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_PATH="$(readlink -f "${BASH_SOURCE[0]}")"
+ROOT_DIR="$(cd "$(dirname "$SCRIPT_PATH")/.." && pwd)"
+VERIFY_SCRIPT="$ROOT_DIR/scripts/verify-decoupled-stack.sh"
+OWUI_BIN="${OWUI_BIN:-$HOME/.local/bin/owui}"
+
+usage() {
+  cat <<'EOF'
+open-terminal - local OpenTerminal control CLI
+
+Usage:
+  open-terminal                 # interactive slash-command REPL
+  open-terminal repl
+  open-terminal start|stop|restart|status|logs|health|verify
+  open-terminal model [profile]
+  open-terminal help
+
+Slash commands inside REPL:
+  /start
+  /stop
+  /restart
+  /status
+  /logs
+  /health
+  /verify
+  /model
+  /model gemma|qwen|openvino|custom <url>
+  /help
+  /quit
+EOF
+}
+
+do_start() { systemctl --user start open-terminal; }
+do_stop() { systemctl --user stop open-terminal; }
+do_restart() { systemctl --user restart open-terminal; }
+do_status() { systemctl --user --no-pager status open-terminal; }
+do_logs() { journalctl --user -u open-terminal -n "${1:-120}" --no-pager; }
+do_health() { curl -fsS http://127.0.0.1:8010/health && echo; }
+do_verify() { "$VERIFY_SCRIPT"; }
+
+do_model() {
+  if [[ ! -x "$OWUI_BIN" ]]; then
+    echo "owui CLI not found at $OWUI_BIN"
+    return 1
+  fi
+
+  if [[ $# -eq 0 ]]; then
+    "$OWUI_BIN" model
+  else
+    "$OWUI_BIN" model "$@"
+  fi
+}
+
+run_repl() {
+  echo "open-terminal REPL. Type /help for commands. Press Ctrl+C to exit."
+  trap 'echo; echo "Exiting open-terminal REPL."; exit 0' INT
+
+  while true; do
+    read -rp "open-terminal> " line || break
+    case "$line" in
+      "" ) continue ;;
+      "/help" ) usage ;;
+      "/quit"|"/exit" ) break ;;
+      "/start" ) do_start ;;
+      "/stop" ) do_stop ;;
+      "/restart" ) do_restart ;;
+      "/status" ) do_status ;;
+      "/logs" ) do_logs ;;
+      "/health" ) do_health || echo "Health check failed." ;;
+      "/verify" ) do_verify || true ;;
+      "/model" ) do_model || true ;;
+      /model\ gemma ) do_model gemma ;;
+      /model\ qwen ) do_model qwen ;;
+      /model\ openvino ) do_model openvino ;;
+      /model\ custom\ * )
+        custom_url="${line#"/model custom "}"
+        if [[ -z "$custom_url" || "$custom_url" == "/model custom " ]]; then
+          echo "Usage: /model custom <url>"
+        else
+          do_model custom "$custom_url"
+        fi
+        ;;
+      /model* )
+        echo "Usage: /model | /model gemma|qwen|openvino|custom <url>"
+        ;;
+      * ) echo "Unknown command: $line" ;;
+    esac
+  done
+}
+
+main() {
+  cmd="${1:-repl}"
+  case "$cmd" in
+    repl) run_repl ;;
+    start) do_start ;;
+    stop) do_stop ;;
+    restart) do_restart ;;
+    status) do_status ;;
+    logs) do_logs "${2:-120}" ;;
+    health) do_health ;;
+    verify) do_verify ;;
+    model)
+      shift || true
+      do_model "$@"
+      ;;
+    help|-h|--help) usage ;;
+    *)
+      echo "Unknown command: $cmd"
+      usage
+      exit 1
+      ;;
+  esac
+}
+
+main "$@"

--- a/scripts/open-terminal
+++ b/scripts/open-terminal
@@ -9,6 +9,8 @@ OWUI_STATE_FILE="${XDG_CONFIG_HOME:-$HOME/.config}/open-webui-custom/model_profi
 DEFAULT_ENDPOINT="http://127.0.0.1:8000/v1"
 CHAT_HISTORY_FILE="${XDG_STATE_HOME:-$HOME/.local/state}/open-terminal/chat_history.jsonl"
 MODEL_ACTIVATE_SCRIPT="${MODEL_ACTIVATE_SCRIPT:-/home/trotsky/Projects/b70-linux-ai-lab/scripts/z490_local_model_activate.sh}"
+WAIT_TIMEOUT_SECONDS="${WAIT_TIMEOUT_SECONDS:-120}"
+OT_AUTO_RETURN_TO_GEMMA=0
 mkdir -p "$(dirname "$CHAT_HISTORY_FILE")"
 
 COMMANDS=(
@@ -27,6 +29,7 @@ COMMANDS=(
   "/model vision"
   "/model gemma"
   "/model qwen (on-demand warm-up)"
+  "/model qwen-temp (one reply, then auto-return to gemma)"
   "/model openvino"
   "/model custom <url>"
   "/endpoint"
@@ -62,7 +65,7 @@ Slash commands inside REPL:
   /health
   /verify
   /model
-  /model text|vision|gemma|qwen|openvino|custom <url>
+  /model text|vision|gemma|qwen|qwen-temp|openvino|custom <url>
   /endpoint
   /endpoint-check
   /clear              # clear local chat history
@@ -81,6 +84,26 @@ do_verify() { "$VERIFY_SCRIPT"; }
 do_clear() {
   : > "$CHAT_HISTORY_FILE"
   echo "Chat history cleared."
+}
+
+wait_for_models_endpoint() {
+  local endpoint models_url waited=0
+  endpoint="$(current_endpoint)"
+  models_url="${endpoint%/}/models"
+  printf "Waiting for endpoint %s " "$endpoint"
+  while (( waited < WAIT_TIMEOUT_SECONDS )); do
+    if curl -fsS "$models_url" >/dev/null 2>&1; then
+      echo
+      echo "Endpoint ready."
+      return 0
+    fi
+    printf "."
+    sleep 2
+    waited=$((waited + 2))
+  done
+  echo
+  echo "Endpoint did not become ready within ${WAIT_TIMEOUT_SECONDS}s."
+  return 1
 }
 
 current_endpoint() {
@@ -270,6 +293,12 @@ PY
   printf '{"role":"user","content":%s}\n' "$(python3 -c 'import json,sys; print(json.dumps(sys.argv[1]))' "$user_text")" >> "$CHAT_HISTORY_FILE"
   printf '{"role":"assistant","content":%s}\n' "$(python3 -c 'import json,sys; print(json.dumps(sys.argv[1]))' "$assistant")" >> "$CHAT_HISTORY_FILE"
   echo "$assistant"
+  if [[ "$OT_AUTO_RETURN_TO_GEMMA" -eq 1 ]]; then
+    OT_AUTO_RETURN_TO_GEMMA=0
+    echo
+    echo "Auto-returning to Gemma primary..."
+    do_model gemma || true
+  fi
 }
 
 do_model() {
@@ -298,8 +327,22 @@ do_model() {
           echo "Proceeding without one-model guard."
         fi
         ;;
+      qwen-temp)
+        if [[ -x "$MODEL_ACTIVATE_SCRIPT" ]]; then
+          echo "Switching to temporary Qwen session (auto-return to Gemma after one reply)."
+          echo "This usually takes around 30-90 seconds depending on load."
+          "$MODEL_ACTIVATE_SCRIPT" qwen
+          OT_AUTO_RETURN_TO_GEMMA=1
+        else
+          echo "Warning: activation script not found at $MODEL_ACTIVATE_SCRIPT"
+          echo "Proceeding without one-model guard."
+          OT_AUTO_RETURN_TO_GEMMA=1
+        fi
+        set -- qwen
+        ;;
     esac
     "$OWUI_BIN" model "$@"
+    wait_for_models_endpoint || true
   fi
 }
 
@@ -343,6 +386,7 @@ run_repl() {
       /model\ vision ) do_model vision ;;
       /model\ gemma ) do_model gemma ;;
       /model\ qwen ) do_model qwen ;;
+      /model\ qwen-temp ) do_model qwen-temp ;;
       /model\ openvino ) do_model openvino ;;
       /model\ custom\ * )
         custom_url="${line#"/model custom "}"
@@ -353,7 +397,7 @@ run_repl() {
         fi
         ;;
       /model* )
-        echo "Usage: /model | /model text|vision|gemma|qwen|openvino|custom <url>"
+        echo "Usage: /model | /model text|vision|gemma|qwen|qwen-temp|openvino|custom <url>"
         ;;
       "/" ) show_commands "/" ;;
       /[a-zA-Z]* )

--- a/scripts/open-terminal
+++ b/scripts/open-terminal
@@ -23,7 +23,62 @@ OT_STATUS_PROMPT="${OT_STATUS_PROMPT:-1}"
 OT_CONTRACT_MODE="${OT_CONTRACT_MODE:-strict}"
 OT_CHAT_RETRY_MAX="${OT_CHAT_RETRY_MAX:-2}"
 CODEX_GEMMA_BIN="${CODEX_GEMMA_BIN:-$ROOT_DIR/scripts/codex-gemma}"
+OT_PRETTY_OUTPUT="${OT_PRETTY_OUTPUT:-auto}"
 mkdir -p "$OT_STATE_DIR" "$OT_CONFIG_DIR" "$OT_SESSIONS_DIR"
+
+CLR_RESET=""
+CLR_GREEN=""
+CLR_RED=""
+CLR_CYAN=""
+
+init_colors() {
+  local use_color=0
+  if [[ "$OT_PRETTY_OUTPUT" == "on" ]]; then
+    use_color=1
+  elif [[ "$OT_PRETTY_OUTPUT" == "auto" ]] && [[ -t 1 ]] && command -v tput >/dev/null 2>&1; then
+    if [[ "$(tput colors 2>/dev/null || echo 0)" -ge 8 ]]; then
+      use_color=1
+    fi
+  fi
+  if [[ "$use_color" -eq 1 ]]; then
+    CLR_RESET=$'\033[0m'
+    CLR_GREEN=$'\033[32m'
+    CLR_RED=$'\033[31m'
+    CLR_CYAN=$'\033[36m'
+  fi
+}
+
+pretty_print_file() {
+  local file="$1"
+  local mode="${2:-plain}"
+  [[ -f "$file" ]] || { echo "Missing file: $file"; return 1; }
+
+  if [[ "$OT_PRETTY_OUTPUT" == "off" ]]; then
+    cat "$file"
+    return 0
+  fi
+
+  if [[ "$mode" == "diff" ]] && command -v delta >/dev/null 2>&1; then
+    delta --line-numbers --paging=never "$file" || cat "$file"
+    return 0
+  fi
+
+  if command -v bat >/dev/null 2>&1; then
+    bat --style=plain,numbers --paging=never --color=always "$file" || cat "$file"
+    return 0
+  fi
+
+  if [[ "$mode" == "diff" ]]; then
+    nl -ba "$file" | awk \
+      -v green="$CLR_GREEN" -v red="$CLR_RED" -v cyan="$CLR_CYAN" -v reset="$CLR_RESET" '
+      /^\s*[0-9]+\s+\+/ { print green $0 reset; next }
+      /^\s*[0-9]+\s+\-/ { print red $0 reset; next }
+      /^\s*[0-9]+\s+@@/ { print cyan $0 reset; next }
+      { print }'
+  else
+    nl -ba "$file"
+  fi
+}
 
 COMMANDS=(
   "/help"
@@ -98,6 +153,9 @@ Usage:
   open-terminal resume --all
   open-terminal session list|new [name]|use <id>
   open-terminal help
+
+Env:
+  OT_PRETTY_OUTPUT=auto|on|off  # numbered/colorized rendering for file outputs
 
 Slash commands inside REPL:
   /
@@ -875,13 +933,21 @@ do_job() {
       [[ -n "$job_id" ]] || { echo "Usage: /job logs <job_id>"; return 1; }
       log="$CG_STATE_DIR/codex-gemma-jobs/${job_id}.log"
       [[ -f "$log" ]] || { echo "No log file yet: $log"; return 1; }
-      tail -n 120 "$log"
+      local tmp_log
+      tmp_log="$(mktemp)"
+      tail -n 120 "$log" > "$tmp_log"
+      pretty_print_file "$tmp_log" plain
+      rm -f "$tmp_log"
       ;;
     result)
       [[ -n "$job_id" ]] || { echo "Usage: /job result <job_id>"; return 1; }
       result="$CG_STATE_DIR/codex-gemma-jobs/${job_id}.result.md"
       [[ -f "$result" ]] || { echo "No result file yet: $result"; return 1; }
-      cat "$result"
+      if rg -q '^(\+\+\+ |--- |@@ )' "$result" 2>/dev/null; then
+        pretty_print_file "$result" diff
+      else
+        pretty_print_file "$result" plain
+      fi
       ;;
     cancel)
       [[ -n "$job_id" ]] || { echo "Usage: /job cancel <job_id>"; return 1; }
@@ -986,6 +1052,7 @@ check_endpoint() {
 }
 
 run_repl() {
+  init_colors
   echo "open-terminal chat REPL."
   echo "Hints: type '/' for interactive menu, '/<prefix>' to filter, TAB to complete, Ctrl+C to exit."
   trap 'echo; echo "Exiting open-terminal REPL."; exit 0' INT

--- a/scripts/otx
+++ b/scripts/otx
@@ -2,6 +2,7 @@
 import argparse
 import json
 import os
+import shlex
 import subprocess
 import sys
 import tempfile
@@ -111,6 +112,12 @@ def cmd_run(args, targets, default):
     command = " ".join(parts).strip()
     if not command:
         raise SystemExit("Missing command.")
+    if args.node_bin:
+        command = f"export PATH={shlex.quote(args.node_bin)}:$PATH; {command}"
+    if args.source_env:
+        command = f"set -a; source {shlex.quote(args.source_env)}; set +a; {command}"
+    if args.login_shell or args.source_env:
+        command = f"bash -lc {shlex.quote(command)}"
     body = {"command": command}
     if args.cwd:
         body["cwd"] = args.cwd
@@ -184,6 +191,9 @@ def build_parser() -> argparse.ArgumentParser:
     run.add_argument("--wait", type=float, default=120.0)
     run.add_argument("--tail", type=int, default=300)
     run.add_argument("--cwd", help="Override cwd for this run")
+    run.add_argument("--login-shell", action="store_true", help="Wrap command with bash -lc")
+    run.add_argument("--source-env", help="Remote env file path to source before command")
+    run.add_argument("--node-bin", help="Remote node bin path prepended to PATH (for nvm installs)")
     run.add_argument("command", nargs=argparse.REMAINDER)
 
     read = sub.add_parser("read", help="Read remote file")

--- a/scripts/otx
+++ b/scripts/otx
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_CONFIG = Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config")) / "open-terminal" / "targets.json"
+
+
+@dataclass
+class Target:
+    name: str
+    base_url: str
+    api_key: str
+    cwd: str | None = None
+    session_id: str | None = None
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def load_targets(path: Path) -> tuple[dict[str, Target], str]:
+    if not path.exists():
+        raise FileNotFoundError(f"Missing config: {path}")
+    raw = _load_json(path)
+    default = str(raw.get("default") or "")
+    targets_raw = raw.get("targets") or {}
+    out: dict[str, Target] = {}
+    for name, cfg in targets_raw.items():
+        out[name] = Target(
+            name=name,
+            base_url=str(cfg["base_url"]).rstrip("/"),
+            api_key=str(cfg["api_key"]),
+            cwd=cfg.get("cwd"),
+            session_id=cfg.get("session_id"),
+        )
+    return out, default
+
+
+def req(target: Target, method: str, path: str, query: dict[str, Any] | None = None, body: dict[str, Any] | None = None):
+    url = target.base_url + path
+    if query:
+        q = urllib.parse.urlencode({k: v for k, v in query.items() if v is not None})
+        url = f"{url}?{q}"
+    headers = {"Authorization": f"Bearer {target.api_key}"}
+    if target.session_id:
+        headers["X-Session-Id"] = target.session_id
+    data = None
+    if body is not None:
+        headers["Content-Type"] = "application/json"
+        data = json.dumps(body).encode("utf-8")
+    request = urllib.request.Request(url=url, method=method, headers=headers, data=data)
+    with urllib.request.urlopen(request, timeout=300) as resp:
+        raw = resp.read()
+    if not raw:
+        return None
+    try:
+        return json.loads(raw)
+    except Exception:
+        return raw.decode("utf-8", errors="replace")
+
+
+def print_execute_output(obj: dict[str, Any]) -> None:
+    for item in obj.get("output") or []:
+        typ = item.get("type", "output")
+        data = item.get("data", "")
+        prefix = "" if typ == "stdout" else f"[{typ}] "
+        sys.stdout.write(prefix + data)
+    if obj.get("status") in {"done", "killed"}:
+        code = obj.get("exit_code")
+        print(f"\n[exit_code={code}]")
+
+
+def cmd_targets(args, targets, default):
+    for name, t in targets.items():
+        marker = "*" if name == default else " "
+        print(f"{marker} {name:8} {t.base_url} cwd={t.cwd or '-'} session={t.session_id or '-'}")
+
+
+def resolve_target(args, targets, default) -> Target:
+    name = args.target or default
+    if not name:
+        raise SystemExit("No target selected. Set default in targets.json or pass --target.")
+    if name not in targets:
+        raise SystemExit(f"Unknown target: {name}")
+    return targets[name]
+
+
+def cmd_health(args, targets, default):
+    t = resolve_target(args, targets, default)
+    url = t.base_url + "/health"
+    with urllib.request.urlopen(url, timeout=10) as resp:
+        print(resp.read().decode("utf-8", errors="replace"))
+
+
+def cmd_run(args, targets, default):
+    t = resolve_target(args, targets, default)
+    parts = list(args.command)
+    if parts and parts[0] == "--":
+      parts = parts[1:]
+    command = " ".join(parts).strip()
+    if not command:
+        raise SystemExit("Missing command.")
+    body = {"command": command}
+    if args.cwd:
+        body["cwd"] = args.cwd
+    elif t.cwd:
+        body["cwd"] = t.cwd
+    obj = req(t, "POST", "/execute", query={"wait": args.wait, "tail": args.tail}, body=body)
+    print_execute_output(obj)
+    return 0 if obj.get("exit_code") in (None, 0) else int(obj.get("exit_code") or 1)
+
+
+def cmd_read(args, targets, default):
+    t = resolve_target(args, targets, default)
+    obj = req(t, "GET", "/files/read", query={"path": args.path, "start_line": args.start_line, "end_line": args.end_line})
+    print(obj.get("content", ""))
+
+
+def cmd_write(args, targets, default):
+    t = resolve_target(args, targets, default)
+    content = Path(args.file).read_text(encoding="utf-8") if args.file else args.text
+    if content is None:
+        raise SystemExit("Use --text or --file.")
+    req(t, "POST", "/files/write", body={"path": args.path, "content": content})
+    print("ok")
+
+
+def cmd_edit(args, targets, default):
+    t = resolve_target(args, targets, default)
+    before = req(t, "GET", "/files/read", query={"path": args.path}).get("content", "")
+    editor = os.environ.get("EDITOR", "nano")
+    with tempfile.TemporaryDirectory(prefix="otx-edit-") as td:
+        local = Path(td) / Path(args.path).name
+        local.write_text(before, encoding="utf-8")
+        subprocess.run([editor, str(local)], check=False)
+        after = local.read_text(encoding="utf-8")
+    if after == before:
+        print("No changes.")
+        return
+    if args.diff:
+        import difflib
+        diff = difflib.unified_diff(before.splitlines(True), after.splitlines(True), fromfile=f"{args.path}:before", tofile=f"{args.path}:after")
+        sys.stdout.writelines(diff)
+        if not args.yes:
+            ans = input("Apply changes? [y/N] ").strip().lower()
+            if ans not in {"y", "yes"}:
+                print("Aborted.")
+                return
+    req(t, "POST", "/files/write", body={"path": args.path, "content": after})
+    print("Applied.")
+
+
+def cmd_logs(args, targets, default):
+    t = resolve_target(args, targets, default)
+    command = f"journalctl --user -u {args.unit} -n {args.lines} --no-pager"
+    body = {"command": command}
+    if t.cwd:
+        body["cwd"] = t.cwd
+    obj = req(t, "POST", "/execute", query={"wait": args.wait, "tail": args.tail}, body=body)
+    print_execute_output(obj)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description="otx - OpenTerminal cross-host target router")
+    p.add_argument("--config", default=str(DEFAULT_CONFIG), help="Path to targets.json")
+    p.add_argument("--target", help="Target name override")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    sub.add_parser("targets", help="List configured targets")
+    sub.add_parser("health", help="Health check selected target")
+
+    run = sub.add_parser("run", help="Run command on target via /execute")
+    run.add_argument("--wait", type=float, default=120.0)
+    run.add_argument("--tail", type=int, default=300)
+    run.add_argument("--cwd", help="Override cwd for this run")
+    run.add_argument("command", nargs=argparse.REMAINDER)
+
+    read = sub.add_parser("read", help="Read remote file")
+    read.add_argument("path")
+    read.add_argument("--start-line", type=int)
+    read.add_argument("--end-line", type=int)
+
+    write = sub.add_parser("write", help="Write remote file")
+    write.add_argument("path")
+    g = write.add_mutually_exclusive_group(required=True)
+    g.add_argument("--text")
+    g.add_argument("--file")
+
+    edit = sub.add_parser("edit", help="Edit remote file via local $EDITOR")
+    edit.add_argument("path")
+    edit.add_argument("--diff", action="store_true", default=True)
+    edit.add_argument("--yes", action="store_true", help="Apply without confirmation when --diff is shown")
+
+    logs = sub.add_parser("logs", help="Read user service logs on target")
+    logs.add_argument("--unit", default="open-terminal")
+    logs.add_argument("--lines", type=int, default=120)
+    logs.add_argument("--wait", type=float, default=30.0)
+    logs.add_argument("--tail", type=int, default=300)
+
+    return p
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    targets, default = load_targets(Path(args.config))
+    if args.cmd == "targets":
+        cmd_targets(args, targets, default)
+        return 0
+    if args.cmd == "health":
+        cmd_health(args, targets, default)
+        return 0
+    if args.cmd == "run":
+        return cmd_run(args, targets, default)
+    if args.cmd == "read":
+        cmd_read(args, targets, default)
+        return 0
+    if args.cmd == "write":
+        cmd_write(args, targets, default)
+        return 0
+    if args.cmd == "edit":
+        cmd_edit(args, targets, default)
+        return 0
+    if args.cmd == "logs":
+        cmd_logs(args, targets, default)
+        return 0
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/otx-benchmark-crosshost
+++ b/scripts/otx-benchmark-crosshost
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OTX_BIN="$ROOT_DIR/scripts/otx"
+CASES_PATH="scripts/model_baseline_cases.json"
+OUT_DIR="scripts/output/model-baseline"
+RETRIES="${RETRIES:-3}"
+WAIT_SECONDS="${WAIT_SECONDS:-300}"
+TARGET_LOCAL="${TARGET_LOCAL:-z490}"
+TARGET_REMOTE="${TARGET_REMOTE:-nuc}"
+
+usage() {
+  cat <<'EOF'
+otx-benchmark-crosshost - run harness benchmark on two otx targets and refresh cross-host summary
+
+Usage:
+  scripts/otx-benchmark-crosshost
+  scripts/otx-benchmark-crosshost --retries 3 --wait 300 --local z490 --remote nuc
+
+Options:
+  --retries N     codex-gemma strict retries (default: 3)
+  --wait SEC      otx run wait timeout in seconds (default: 300)
+  --local NAME    local target alias (default: z490)
+  --remote NAME   remote target alias (default: nuc)
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --retries) shift; RETRIES="${1:-3}" ;;
+    --wait) shift; WAIT_SECONDS="${1:-300}" ;;
+    --local) shift; TARGET_LOCAL="${1:-z490}" ;;
+    --remote) shift; TARGET_REMOTE="${1:-nuc}" ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown arg: $1"; usage; exit 1 ;;
+  esac
+  shift || true
+done
+
+if ! [[ "$RETRIES" =~ ^[0-9]+$ ]]; then
+  echo "Invalid retries: $RETRIES"
+  exit 1
+fi
+if ! [[ "$WAIT_SECONDS" =~ ^[0-9]+$ ]]; then
+  echo "Invalid wait: $WAIT_SECONDS"
+  exit 1
+fi
+
+run_suite_for_target() {
+  local target="$1"
+  local suffix="$2"
+  local out_json="$OUT_DIR/baseline.harness.gemma.10cases.${suffix}.json"
+  local out_md="$OUT_DIR/baseline.harness.gemma.10cases.${suffix}.md"
+  local cmd="cd $ROOT_DIR && python3 scripts/model_baseline_suite.py --mode harness --models gemma --retries $RETRIES --cases $CASES_PATH --out-json $out_json --out-md $out_md"
+  "$OTX_BIN" --target "$target" run --wait "$WAIT_SECONDS" -- "$cmd"
+}
+
+fetch_artifact() {
+  local target="$1"
+  local remote_path="$2"
+  local local_path="$3"
+  mkdir -p "$(dirname "$local_path")"
+  local tmp
+  tmp="$(mktemp)"
+  "$OTX_BIN" --target "$target" run --wait 120 -- "cat '$remote_path'" \
+    | sed '/^\[exit_code=/d' \
+    | sed 's/^\[output\] //' > "$tmp"
+  mv "$tmp" "$local_path"
+}
+
+parse_summary() {
+  local path="$1"
+  python3 - "$path" <<'PY'
+import json,sys
+p=sys.argv[1]
+d=json.load(open(p,encoding="utf-8"))
+m=d.get("models",{}).get("gemma",{})
+s=m.get("summary",{})
+print(s.get("passed",0), s.get("total",0), s.get("compliance_percent",0.0), s.get("avg_latency_ms",0))
+PY
+}
+
+echo "== Running suite on $TARGET_LOCAL =="
+run_suite_for_target "$TARGET_LOCAL" "z490"
+
+echo "== Running suite on $TARGET_REMOTE =="
+run_suite_for_target "$TARGET_REMOTE" "nuc"
+
+LOCAL_JSON="$ROOT_DIR/$OUT_DIR/baseline.harness.gemma.10cases.z490.json"
+LOCAL_MD="$ROOT_DIR/$OUT_DIR/baseline.harness.gemma.10cases.z490.md"
+REMOTE_JSON="$ROOT_DIR/$OUT_DIR/baseline.harness.gemma.10cases.nuc.json"
+REMOTE_MD="$ROOT_DIR/$OUT_DIR/baseline.harness.gemma.10cases.nuc.md"
+
+echo "== Syncing artifacts back via otx =="
+fetch_artifact "$TARGET_LOCAL" "$ROOT_DIR/$OUT_DIR/baseline.harness.gemma.10cases.z490.json" "$LOCAL_JSON"
+fetch_artifact "$TARGET_LOCAL" "$ROOT_DIR/$OUT_DIR/baseline.harness.gemma.10cases.z490.md" "$LOCAL_MD"
+fetch_artifact "$TARGET_REMOTE" "$ROOT_DIR/$OUT_DIR/baseline.harness.gemma.10cases.nuc.json" "$REMOTE_JSON"
+fetch_artifact "$TARGET_REMOTE" "$ROOT_DIR/$OUT_DIR/baseline.harness.gemma.10cases.nuc.md" "$REMOTE_MD"
+
+read -r z_pass z_total z_pct z_lat <<<"$(parse_summary "$LOCAL_JSON")"
+read -r n_pass n_total n_pct n_lat <<<"$(parse_summary "$REMOTE_JSON")"
+delta=$((n_lat - z_lat))
+
+CROSS_MD="$ROOT_DIR/$OUT_DIR/baseline.harness.gemma.10cases.cross-host.md"
+cat > "$CROSS_MD" <<EOF
+# Cross-Host Harness Benchmark (Gemma, 10 Cases)
+
+- generated_at: \`$(date -u +%Y-%m-%dT%H:%M:%SZ)\`
+- suite: \`$CASES_PATH\`
+- mode: \`harness\` (\`codex-gemma ask\` strict policy path)
+
+## Summary
+
+- z490 compliance: \`${z_pass}/${z_total}\` (${z_pct}%)
+- nuc compliance: \`${n_pass}/${n_total}\` (${n_pct}%)
+- z490 avg latency: \`${z_lat} ms\`
+- nuc avg latency: \`${n_lat} ms\`
+- delta (nuc - z490): \`${delta} ms\`
+
+## Artifacts
+
+- \`baseline.harness.gemma.10cases.z490.json\`
+- \`baseline.harness.gemma.10cases.z490.md\`
+- \`baseline.harness.gemma.10cases.nuc.json\`
+- \`baseline.harness.gemma.10cases.nuc.md\`
+EOF
+
+echo "== Done =="
+echo "$LOCAL_JSON"
+echo "$REMOTE_JSON"
+echo "$CROSS_MD"

--- a/scripts/otx-benchmark-crosshost
+++ b/scripts/otx-benchmark-crosshost
@@ -19,7 +19,7 @@ Usage:
   scripts/otx-benchmark-crosshost --retries 3 --wait 300 --local z490 --remote nuc
 
 Options:
-  --retries N     codex-gemma strict retries (default: 3)
+  --retries N     historical codex-gemma strict retries (default: 3)
   --wait SEC      otx run wait timeout in seconds (default: 300)
   --local NAME    local target alias (default: z490)
   --remote NAME   remote target alias (default: nuc)
@@ -47,12 +47,22 @@ if ! [[ "$WAIT_SECONDS" =~ ^[0-9]+$ ]]; then
   exit 1
 fi
 
+if [[ "${CODEX_GEMMA_ALLOW_HISTORICAL:-0}" != "1" ]]; then
+  cat <<'EOF'
+Retired: codex-gemma harness benchmarking is no longer part of the active Open Terminal operational path.
+Use packet-mediated local-worker delegation instead.
+
+Set CODEX_GEMMA_ALLOW_HISTORICAL=1 only if you need the historical benchmark path for migration or archival comparison.
+EOF
+  exit 1
+fi
+
 run_suite_for_target() {
   local target="$1"
   local suffix="$2"
   local out_json="$OUT_DIR/baseline.harness.gemma.10cases.${suffix}.json"
   local out_md="$OUT_DIR/baseline.harness.gemma.10cases.${suffix}.md"
-  local cmd="cd $ROOT_DIR && python3 scripts/model_baseline_suite.py --mode harness --models gemma --retries $RETRIES --cases $CASES_PATH --out-json $out_json --out-md $out_md"
+  local cmd="cd $ROOT_DIR && CODEX_GEMMA_ALLOW_HISTORICAL=1 python3 scripts/model_baseline_suite.py --mode harness --models gemma --retries $RETRIES --cases $CASES_PATH --out-json $out_json --out-md $out_md"
   "$OTX_BIN" --target "$target" run --wait "$WAIT_SECONDS" -- "$cmd"
 }
 
@@ -108,7 +118,7 @@ cat > "$CROSS_MD" <<EOF
 
 - generated_at: \`$(date -u +%Y-%m-%dT%H:%M:%SZ)\`
 - suite: \`$CASES_PATH\`
-- mode: \`harness\` (\`codex-gemma ask\` strict policy path)
+- mode: \`harness\` (\`historical codex-gemma ask\` strict policy path)
 
 ## Summary
 

--- a/scripts/output/model-baseline/baseline.gemma-only.json
+++ b/scripts/output/model-baseline/baseline.gemma-only.json
@@ -1,0 +1,41 @@
+{
+  "report_type": "open-terminal-model-baseline",
+  "generated_at": "2026-05-11T13:02:16Z",
+  "cases_path": "scripts/model_baseline_cases.json",
+  "models": {
+    "gemma": {
+      "status": "ok",
+      "endpoint": "http://127.0.0.1:8000/v1",
+      "model_id": "gemma-4-26B-A4B-it.Q4_K_H.gguf",
+      "summary": {
+        "passed": 3,
+        "total": 3,
+        "compliance_percent": 100.0,
+        "avg_latency_ms": 3206
+      },
+      "results": [
+        {
+          "case_id": "codeblock_only",
+          "ok": true,
+          "latency_ms": 975,
+          "detail": "ok",
+          "output_preview": "```python\\ndef add(a: int, b: int) -> int:\\n    return a + b\\n\\nassert add(2, 3) == 5\\n```"
+        },
+        {
+          "case_id": "group_anagrams_contract",
+          "ok": true,
+          "latency_ms": 8313,
+          "detail": "ok",
+          "output_preview": "```python\\nfrom collections import OrderedDict\\n\\ndef group_anagrams(words: list[str]) -> list[list[str]]:\\n    \"\"\"\\n    Groups anagrams together while preserving original word order wi"
+        },
+        {
+          "case_id": "exact_literal",
+          "ok": true,
+          "latency_ms": 332,
+          "detail": "ok",
+          "output_preview": "OK_7F3C"
+        }
+      ]
+    }
+  }
+}

--- a/scripts/output/model-baseline/baseline.gemma-only.md
+++ b/scripts/output/model-baseline/baseline.gemma-only.md
@@ -1,0 +1,17 @@
+# OpenTerminal Model Baseline
+
+- generated_at: `2026-05-11T13:02:16Z`
+- cases: `scripts/model_baseline_cases.json`
+
+## gemma
+
+- endpoint: `http://127.0.0.1:8000/v1`
+- model_id: `gemma-4-26B-A4B-it.Q4_K_H.gguf`
+- compliance: `3/3` (100.0%)
+- avg_latency_ms: `3206`
+
+| case | ok | latency_ms | detail |
+|---|---:|---:|---|
+| `codeblock_only` | `True` | `975` | ok |
+| `group_anagrams_contract` | `True` | `8313` | ok |
+| `exact_literal` | `True` | `332` | ok |

--- a/scripts/output/model-baseline/baseline.harness.gemma.10cases.cross-host.md
+++ b/scripts/output/model-baseline/baseline.harness.gemma.10cases.cross-host.md
@@ -1,6 +1,6 @@
 # Cross-Host Harness Benchmark (Gemma, 10 Cases)
 
-- generated_at: `2026-05-11`
+- generated_at: `2026-05-11T15:53:06Z`
 - suite: `scripts/model_baseline_cases.json`
 - mode: `harness` (`codex-gemma ask` strict policy path)
 
@@ -8,15 +8,9 @@
 
 - z490 compliance: `10/10` (100.0%)
 - nuc compliance: `10/10` (100.0%)
-- z490 avg latency: `4840 ms`
-- nuc avg latency: `5011 ms`
-- delta (nuc - z490): `+171 ms` (about `+3.5%`)
-
-## Interpretation
-
-- Policy correctness is stable across hosts (no compliance drift).
-- Latency is slightly higher on NUC route in this run, but close enough that no policy changes are required.
-- No validation/fallback/request failure taxonomy events were emitted during this benchmark window.
+- z490 avg latency: `2632 ms`
+- nuc avg latency: `2743 ms`
+- delta (nuc - z490): `111 ms`
 
 ## Artifacts
 

--- a/scripts/output/model-baseline/baseline.harness.gemma.10cases.cross-host.md
+++ b/scripts/output/model-baseline/baseline.harness.gemma.10cases.cross-host.md
@@ -1,0 +1,26 @@
+# Cross-Host Harness Benchmark (Gemma, 10 Cases)
+
+- generated_at: `2026-05-11`
+- suite: `scripts/model_baseline_cases.json`
+- mode: `harness` (`codex-gemma ask` strict policy path)
+
+## Summary
+
+- z490 compliance: `10/10` (100.0%)
+- nuc compliance: `10/10` (100.0%)
+- z490 avg latency: `4840 ms`
+- nuc avg latency: `5011 ms`
+- delta (nuc - z490): `+171 ms` (about `+3.5%`)
+
+## Interpretation
+
+- Policy correctness is stable across hosts (no compliance drift).
+- Latency is slightly higher on NUC route in this run, but close enough that no policy changes are required.
+- No validation/fallback/request failure taxonomy events were emitted during this benchmark window.
+
+## Artifacts
+
+- `baseline.harness.gemma.10cases.z490.json`
+- `baseline.harness.gemma.10cases.z490.md`
+- `baseline.harness.gemma.10cases.nuc.json`
+- `baseline.harness.gemma.10cases.nuc.md`

--- a/scripts/output/model-baseline/baseline.harness.gemma.10cases.json
+++ b/scripts/output/model-baseline/baseline.harness.gemma.10cases.json
@@ -1,0 +1,91 @@
+{
+  "report_type": "open-terminal-model-baseline",
+  "generated_at": "2026-05-11T13:27:42Z",
+  "cases_path": "scripts/model_baseline_cases.json",
+  "mode": "harness",
+  "models": {
+    "gemma": {
+      "status": "ok",
+      "endpoint": "via-codex-gemma",
+      "model_id": "codex-gemma-policy-path",
+      "summary": {
+        "passed": 10,
+        "total": 10,
+        "compliance_percent": 100.0,
+        "avg_latency_ms": 2640
+      },
+      "results": [
+        {
+          "case_id": "codeblock_only",
+          "ok": true,
+          "latency_ms": 1065,
+          "detail": "ok",
+          "output_preview": "```python\\ndef add(a: int, b: int) -> int:\\n    return a + b\\n\\nassert add(2, 3) == 5\\n```"
+        },
+        {
+          "case_id": "codeblock_factorial",
+          "ok": true,
+          "latency_ms": 2611,
+          "detail": "ok",
+          "output_preview": "```python\\ndef factorial(n: int) -> int:\\n    if not isinstance(n, int):\\n        raise TypeError(\"Input must be an integer.\")\\n    if n < 0:\\n        raise ValueError(\"Input must be a "
+        },
+        {
+          "case_id": "group_anagrams_contract",
+          "ok": true,
+          "latency_ms": 8355,
+          "detail": "ok",
+          "output_preview": "```python\\nfrom collections import OrderedDict\\n\\ndef group_anagrams(words: list[str]) -> list[list[str]]:\\n    \"\"\"\\n    Groups anagrams together while preserving original word order wi"
+        },
+        {
+          "case_id": "group_anagrams_contract_repeat",
+          "ok": true,
+          "latency_ms": 8516,
+          "detail": "ok",
+          "output_preview": "```python\\nfrom collections import OrderedDict\\n\\ndef group_anagrams(words: list[str]) -> list[list[str]]:\\n    \"\"\"\\n    Groups anagrams together from a list of words.\\n    \\n    Groups a"
+        },
+        {
+          "case_id": "exact_literal",
+          "ok": true,
+          "latency_ms": 442,
+          "detail": "ok",
+          "output_preview": "OK_7F3C"
+        },
+        {
+          "case_id": "exact_literal_alt",
+          "ok": true,
+          "latency_ms": 469,
+          "detail": "ok",
+          "output_preview": "PASS_TOKEN_91A"
+        },
+        {
+          "case_id": "exact_literal_short",
+          "ok": true,
+          "latency_ms": 366,
+          "detail": "ok",
+          "output_preview": "A1"
+        },
+        {
+          "case_id": "codeblock_sum_list",
+          "ok": true,
+          "latency_ms": 1483,
+          "detail": "ok",
+          "output_preview": "```python\\ndef sum_positive(nums: list[int]) -> int:\\n    return sum(x for x in nums if x > 0)\\n\\nassert sum_positive([-1, 2, -3, 4, 0, 5]) == 11\\n```"
+        },
+        {
+          "case_id": "codeblock_reverse_words",
+          "ok": true,
+          "latency_ms": 1238,
+          "detail": "ok",
+          "output_preview": "```python\\ndef reverse_words(s: str) -> str:\\n    return \" \".join(s.split()[::-1])\\n\\nassert reverse_words(\"the sky is blue\") == \"blue is sky the\"\\n```"
+        },
+        {
+          "case_id": "codeblock_palindrome",
+          "ok": true,
+          "latency_ms": 1864,
+          "detail": "ok",
+          "output_preview": "```python\\ndef is_palindrome(s: str) -> bool:\\n    \"\"\"Checks if a string is a palindrome.\"\"\"\\n    clean_s = \"\".join(char.lower() for char in s if char.isalnum())\\n    return clean_s =="
+        }
+      ]
+    }
+  }
+}

--- a/scripts/output/model-baseline/baseline.harness.gemma.10cases.md
+++ b/scripts/output/model-baseline/baseline.harness.gemma.10cases.md
@@ -1,0 +1,25 @@
+# OpenTerminal Model Baseline
+
+- generated_at: `2026-05-11T13:27:42Z`
+- cases: `scripts/model_baseline_cases.json`
+- mode: `harness`
+
+## gemma
+
+- endpoint: `via-codex-gemma`
+- model_id: `codex-gemma-policy-path`
+- compliance: `10/10` (100.0%)
+- avg_latency_ms: `2640`
+
+| case | ok | latency_ms | detail |
+|---|---:|---:|---|
+| `codeblock_only` | `True` | `1065` | ok |
+| `codeblock_factorial` | `True` | `2611` | ok |
+| `group_anagrams_contract` | `True` | `8355` | ok |
+| `group_anagrams_contract_repeat` | `True` | `8516` | ok |
+| `exact_literal` | `True` | `442` | ok |
+| `exact_literal_alt` | `True` | `469` | ok |
+| `exact_literal_short` | `True` | `366` | ok |
+| `codeblock_sum_list` | `True` | `1483` | ok |
+| `codeblock_reverse_words` | `True` | `1238` | ok |
+| `codeblock_palindrome` | `True` | `1864` | ok |

--- a/scripts/output/model-baseline/baseline.harness.gemma.10cases.nuc.json
+++ b/scripts/output/model-baseline/baseline.harness.gemma.10cases.nuc.json
@@ -1,0 +1,91 @@
+{
+  "report_type": "open-terminal-model-baseline",
+  "generated_at": "2026-05-11T15:44:28Z",
+  "cases_path": "scripts/model_baseline_cases.json",
+  "mode": "harness",
+  "models": {
+    "gemma": {
+      "status": "ok",
+      "endpoint": "via-codex-gemma",
+      "model_id": "codex-gemma-policy-path",
+      "summary": {
+        "passed": 10,
+        "total": 10,
+        "compliance_percent": 100.0,
+        "avg_latency_ms": 5011
+      },
+      "results": [
+        {
+          "case_id": "codeblock_only",
+          "ok": true,
+          "latency_ms": 1889,
+          "detail": "ok",
+          "output_preview": "```python\\ndef add(a: int, b: int) -> int:\\n    return a + b\\n\\nassert add(2, 3) == 5\\n```"
+        },
+        {
+          "case_id": "codeblock_factorial",
+          "ok": true,
+          "latency_ms": 4875,
+          "detail": "ok",
+          "output_preview": "```python\\ndef factorial(n: int) -> int:\\n    if not isinstance(n, int):\\n        raise TypeError(\"Input must be an integer.\")\\n    if n < 0:\\n        raise ValueError(\"Input must be a "
+        },
+        {
+          "case_id": "group_anagrams_contract",
+          "ok": true,
+          "latency_ms": 16056,
+          "detail": "ok",
+          "output_preview": "```python\\nfrom collections import OrderedDict\\n\\ndef group_anagrams(words: list[str]) -> list[list[str]]:\\n    \"\"\"\\n    Groups anagrams together while preserving original word order wi"
+        },
+        {
+          "case_id": "group_anagrams_contract_repeat",
+          "ok": true,
+          "latency_ms": 16562,
+          "detail": "ok",
+          "output_preview": "```python\\nfrom collections import OrderedDict\\n\\ndef group_anagrams(words: list[str]) -> list[list[str]]:\\n    \"\"\"\\n    Groups anagrams together from a list of words.\\n    \\n    Groups a"
+        },
+        {
+          "case_id": "exact_literal",
+          "ok": true,
+          "latency_ms": 887,
+          "detail": "ok",
+          "output_preview": "OK_7F3C"
+        },
+        {
+          "case_id": "exact_literal_alt",
+          "ok": true,
+          "latency_ms": 736,
+          "detail": "ok",
+          "output_preview": "PASS_TOKEN_91A"
+        },
+        {
+          "case_id": "exact_literal_short",
+          "ok": true,
+          "latency_ms": 503,
+          "detail": "ok",
+          "output_preview": "A1"
+        },
+        {
+          "case_id": "codeblock_sum_list",
+          "ok": true,
+          "latency_ms": 2768,
+          "detail": "ok",
+          "output_preview": "```python\\ndef sum_positive(nums: list[int]) -> int:\\n    return sum(x for x in nums if x > 0)\\n\\nassert sum_positive([-1, 2, -3, 4, 0, 5]) == 11\\n```"
+        },
+        {
+          "case_id": "codeblock_reverse_words",
+          "ok": true,
+          "latency_ms": 2276,
+          "detail": "ok",
+          "output_preview": "```python\\ndef reverse_words(s: str) -> str:\\n    return \" \".join(s.split()[::-1])\\n\\nassert reverse_words(\"the sky is blue\") == \"blue is sky the\"\\n```"
+        },
+        {
+          "case_id": "codeblock_palindrome",
+          "ok": true,
+          "latency_ms": 3564,
+          "detail": "ok",
+          "output_preview": "```python\\ndef is_palindrome(s: str) -> bool:\\n    \"\"\"Checks if a string is a palindrome.\"\"\"\\n    clean_s = \"\".join(char.lower() for char in s if char.isalnum())\\n    return clean_s =="
+        }
+      ]
+    }
+  }
+}

--- a/scripts/output/model-baseline/baseline.harness.gemma.10cases.nuc.json
+++ b/scripts/output/model-baseline/baseline.harness.gemma.10cases.nuc.json
@@ -1,6 +1,6 @@
 {
   "report_type": "open-terminal-model-baseline",
-  "generated_at": "2026-05-11T15:44:28Z",
+  "generated_at": "2026-05-11T15:52:39Z",
   "cases_path": "scripts/model_baseline_cases.json",
   "mode": "harness",
   "models": {
@@ -12,76 +12,76 @@
         "passed": 10,
         "total": 10,
         "compliance_percent": 100.0,
-        "avg_latency_ms": 5011
+        "avg_latency_ms": 2743
       },
       "results": [
         {
           "case_id": "codeblock_only",
           "ok": true,
-          "latency_ms": 1889,
+          "latency_ms": 1148,
           "detail": "ok",
           "output_preview": "```python\\ndef add(a: int, b: int) -> int:\\n    return a + b\\n\\nassert add(2, 3) == 5\\n```"
         },
         {
           "case_id": "codeblock_factorial",
           "ok": true,
-          "latency_ms": 4875,
+          "latency_ms": 2699,
           "detail": "ok",
           "output_preview": "```python\\ndef factorial(n: int) -> int:\\n    if not isinstance(n, int):\\n        raise TypeError(\"Input must be an integer.\")\\n    if n < 0:\\n        raise ValueError(\"Input must be a "
         },
         {
           "case_id": "group_anagrams_contract",
           "ok": true,
-          "latency_ms": 16056,
+          "latency_ms": 7842,
           "detail": "ok",
           "output_preview": "```python\\nfrom collections import OrderedDict\\n\\ndef group_anagrams(words: list[str]) -> list[list[str]]:\\n    \"\"\"\\n    Groups anagrams together while preserving original word order wi"
         },
         {
           "case_id": "group_anagrams_contract_repeat",
           "ok": true,
-          "latency_ms": 16562,
+          "latency_ms": 9351,
           "detail": "ok",
-          "output_preview": "```python\\nfrom collections import OrderedDict\\n\\ndef group_anagrams(words: list[str]) -> list[list[str]]:\\n    \"\"\"\\n    Groups anagrams together from a list of words.\\n    \\n    Groups a"
+          "output_preview": "```python\\nfrom collections import OrderedDict\\n\\ndef group_anagrams(words: list[str]) -> list[list[str]]:\\n    \"\"\"\\n    Groups anagrams together while preserving the original order of "
         },
         {
           "case_id": "exact_literal",
           "ok": true,
-          "latency_ms": 887,
+          "latency_ms": 537,
           "detail": "ok",
           "output_preview": "OK_7F3C"
         },
         {
           "case_id": "exact_literal_alt",
           "ok": true,
-          "latency_ms": 736,
+          "latency_ms": 592,
           "detail": "ok",
           "output_preview": "PASS_TOKEN_91A"
         },
         {
           "case_id": "exact_literal_short",
           "ok": true,
-          "latency_ms": 503,
+          "latency_ms": 427,
           "detail": "ok",
           "output_preview": "A1"
         },
         {
           "case_id": "codeblock_sum_list",
           "ok": true,
-          "latency_ms": 2768,
+          "latency_ms": 1610,
           "detail": "ok",
           "output_preview": "```python\\ndef sum_positive(nums: list[int]) -> int:\\n    return sum(x for x in nums if x > 0)\\n\\nassert sum_positive([-1, 2, -3, 4, 0, 5]) == 11\\n```"
         },
         {
           "case_id": "codeblock_reverse_words",
           "ok": true,
-          "latency_ms": 2276,
+          "latency_ms": 1321,
           "detail": "ok",
           "output_preview": "```python\\ndef reverse_words(s: str) -> str:\\n    return \" \".join(s.split()[::-1])\\n\\nassert reverse_words(\"the sky is blue\") == \"blue is sky the\"\\n```"
         },
         {
           "case_id": "codeblock_palindrome",
           "ok": true,
-          "latency_ms": 3564,
+          "latency_ms": 1907,
           "detail": "ok",
           "output_preview": "```python\\ndef is_palindrome(s: str) -> bool:\\n    \"\"\"Checks if a string is a palindrome.\"\"\"\\n    clean_s = \"\".join(char.lower() for char in s if char.isalnum())\\n    return clean_s =="
         }

--- a/scripts/output/model-baseline/baseline.harness.gemma.10cases.nuc.md
+++ b/scripts/output/model-baseline/baseline.harness.gemma.10cases.nuc.md
@@ -1,0 +1,25 @@
+# OpenTerminal Model Baseline
+
+- generated_at: `2026-05-11T15:44:28Z`
+- cases: `scripts/model_baseline_cases.json`
+- mode: `harness`
+
+## gemma
+
+- endpoint: `via-codex-gemma`
+- model_id: `codex-gemma-policy-path`
+- compliance: `10/10` (100.0%)
+- avg_latency_ms: `5011`
+
+| case | ok | latency_ms | detail |
+|---|---:|---:|---|
+| `codeblock_only` | `True` | `1889` | ok |
+| `codeblock_factorial` | `True` | `4875` | ok |
+| `group_anagrams_contract` | `True` | `16056` | ok |
+| `group_anagrams_contract_repeat` | `True` | `16562` | ok |
+| `exact_literal` | `True` | `887` | ok |
+| `exact_literal_alt` | `True` | `736` | ok |
+| `exact_literal_short` | `True` | `503` | ok |
+| `codeblock_sum_list` | `True` | `2768` | ok |
+| `codeblock_reverse_words` | `True` | `2276` | ok |
+| `codeblock_palindrome` | `True` | `3564` | ok |

--- a/scripts/output/model-baseline/baseline.harness.gemma.10cases.nuc.md
+++ b/scripts/output/model-baseline/baseline.harness.gemma.10cases.nuc.md
@@ -1,6 +1,6 @@
 # OpenTerminal Model Baseline
 
-- generated_at: `2026-05-11T15:44:28Z`
+- generated_at: `2026-05-11T15:52:39Z`
 - cases: `scripts/model_baseline_cases.json`
 - mode: `harness`
 
@@ -9,17 +9,18 @@
 - endpoint: `via-codex-gemma`
 - model_id: `codex-gemma-policy-path`
 - compliance: `10/10` (100.0%)
-- avg_latency_ms: `5011`
+- avg_latency_ms: `2743`
 
 | case | ok | latency_ms | detail |
 |---|---:|---:|---|
-| `codeblock_only` | `True` | `1889` | ok |
-| `codeblock_factorial` | `True` | `4875` | ok |
-| `group_anagrams_contract` | `True` | `16056` | ok |
-| `group_anagrams_contract_repeat` | `True` | `16562` | ok |
-| `exact_literal` | `True` | `887` | ok |
-| `exact_literal_alt` | `True` | `736` | ok |
-| `exact_literal_short` | `True` | `503` | ok |
-| `codeblock_sum_list` | `True` | `2768` | ok |
-| `codeblock_reverse_words` | `True` | `2276` | ok |
-| `codeblock_palindrome` | `True` | `3564` | ok |
+| `codeblock_only` | `True` | `1148` | ok |
+| `codeblock_factorial` | `True` | `2699` | ok |
+| `group_anagrams_contract` | `True` | `7842` | ok |
+| `group_anagrams_contract_repeat` | `True` | `9351` | ok |
+| `exact_literal` | `True` | `537` | ok |
+| `exact_literal_alt` | `True` | `592` | ok |
+| `exact_literal_short` | `True` | `427` | ok |
+| `codeblock_sum_list` | `True` | `1610` | ok |
+| `codeblock_reverse_words` | `True` | `1321` | ok |
+| `codeblock_palindrome` | `True` | `1907` | ok |
+

--- a/scripts/output/model-baseline/baseline.harness.gemma.10cases.z490.json
+++ b/scripts/output/model-baseline/baseline.harness.gemma.10cases.z490.json
@@ -1,0 +1,91 @@
+{
+  "report_type": "open-terminal-model-baseline",
+  "generated_at": "2026-05-11T15:44:28Z",
+  "cases_path": "scripts/model_baseline_cases.json",
+  "mode": "harness",
+  "models": {
+    "gemma": {
+      "status": "ok",
+      "endpoint": "via-codex-gemma",
+      "model_id": "codex-gemma-policy-path",
+      "summary": {
+        "passed": 10,
+        "total": 10,
+        "compliance_percent": 100.0,
+        "avg_latency_ms": 4840
+      },
+      "results": [
+        {
+          "case_id": "codeblock_only",
+          "ok": true,
+          "latency_ms": 1045,
+          "detail": "ok",
+          "output_preview": "```python\\ndef add(a: int, b: int) -> int:\\n    return a + b\\n\\nassert add(2, 3) == 5\\n```"
+        },
+        {
+          "case_id": "codeblock_factorial",
+          "ok": true,
+          "latency_ms": 3320,
+          "detail": "ok",
+          "output_preview": "```python\\ndef factorial(n: int) -> int:\\n    if not isinstance(n, int):\\n        raise TypeError(\"Input must be an integer.\")\\n    if n < 0:\\n        raise ValueError(\"Input must be a "
+        },
+        {
+          "case_id": "group_anagrams_contract",
+          "ok": true,
+          "latency_ms": 10732,
+          "detail": "ok",
+          "output_preview": "```python\\nfrom collections import OrderedDict\\n\\ndef group_anagrams(words: list[str]) -> list[list[str]]:\\n    \"\"\"\\n    Groups anagrams together while preserving original word order wi"
+        },
+        {
+          "case_id": "group_anagrams_contract_repeat",
+          "ok": true,
+          "latency_ms": 15986,
+          "detail": "ok",
+          "output_preview": "```python\\nfrom collections import OrderedDict\\n\\ndef group_anagrams(words: list[str]) -> list[list[str]]:\\n    \"\"\"\\n    Groups anagrams together while preserving original word order wi"
+        },
+        {
+          "case_id": "exact_literal",
+          "ok": true,
+          "latency_ms": 8909,
+          "detail": "ok",
+          "output_preview": "OK_7F3C"
+        },
+        {
+          "case_id": "exact_literal_alt",
+          "ok": true,
+          "latency_ms": 705,
+          "detail": "ok",
+          "output_preview": "PASS_TOKEN_91A"
+        },
+        {
+          "case_id": "exact_literal_short",
+          "ok": true,
+          "latency_ms": 619,
+          "detail": "ok",
+          "output_preview": "A1"
+        },
+        {
+          "case_id": "codeblock_sum_list",
+          "ok": true,
+          "latency_ms": 1626,
+          "detail": "ok",
+          "output_preview": "```python\\ndef sum_positive(nums: list[int]) -> int:\\n    return sum(x for x in nums if x > 0)\\n\\nassert sum_positive([-1, 2, -3, 4, 0, 5]) == 11\\n```"
+        },
+        {
+          "case_id": "codeblock_reverse_words",
+          "ok": true,
+          "latency_ms": 2537,
+          "detail": "ok",
+          "output_preview": "```python\\ndef reverse_words(s: str) -> str:\\n    return \" \".join(s.split()[::-1])\\n\\nassert reverse_words(\"the sky is blue\") == \"blue is sky the\"\\n```"
+        },
+        {
+          "case_id": "codeblock_palindrome",
+          "ok": true,
+          "latency_ms": 2925,
+          "detail": "ok",
+          "output_preview": "```python\\ndef is_palindrome(s: str) -> bool:\\n    \"\"\"Checks if a string is a palindrome.\"\"\"\\n    clean_s = \"\".join(char.lower() for char in s if char.isalnum())\\n    return clean_s =="
+        }
+      ]
+    }
+  }
+}

--- a/scripts/output/model-baseline/baseline.harness.gemma.10cases.z490.json
+++ b/scripts/output/model-baseline/baseline.harness.gemma.10cases.z490.json
@@ -1,6 +1,6 @@
 {
   "report_type": "open-terminal-model-baseline",
-  "generated_at": "2026-05-11T15:44:28Z",
+  "generated_at": "2026-05-11T15:52:12Z",
   "cases_path": "scripts/model_baseline_cases.json",
   "mode": "harness",
   "models": {
@@ -12,76 +12,76 @@
         "passed": 10,
         "total": 10,
         "compliance_percent": 100.0,
-        "avg_latency_ms": 4840
+        "avg_latency_ms": 2632
       },
       "results": [
         {
           "case_id": "codeblock_only",
           "ok": true,
-          "latency_ms": 1045,
+          "latency_ms": 1083,
           "detail": "ok",
           "output_preview": "```python\\ndef add(a: int, b: int) -> int:\\n    return a + b\\n\\nassert add(2, 3) == 5\\n```"
         },
         {
           "case_id": "codeblock_factorial",
           "ok": true,
-          "latency_ms": 3320,
+          "latency_ms": 2751,
           "detail": "ok",
           "output_preview": "```python\\ndef factorial(n: int) -> int:\\n    if not isinstance(n, int):\\n        raise TypeError(\"Input must be an integer.\")\\n    if n < 0:\\n        raise ValueError(\"Input must be a "
         },
         {
           "case_id": "group_anagrams_contract",
           "ok": true,
-          "latency_ms": 10732,
+          "latency_ms": 8109,
           "detail": "ok",
-          "output_preview": "```python\\nfrom collections import OrderedDict\\n\\ndef group_anagrams(words: list[str]) -> list[list[str]]:\\n    \"\"\"\\n    Groups anagrams together while preserving original word order wi"
+          "output_preview": "```python\\nfrom collections import OrderedDict\\n\\ndef group_anagrams(words: list[str]) -> list[list[str]]:\\n    \"\"\"\\n    Groups anagrams together while preserving original order of grou"
         },
         {
           "case_id": "group_anagrams_contract_repeat",
           "ok": true,
-          "latency_ms": 15986,
+          "latency_ms": 8116,
           "detail": "ok",
           "output_preview": "```python\\nfrom collections import OrderedDict\\n\\ndef group_anagrams(words: list[str]) -> list[list[str]]:\\n    \"\"\"\\n    Groups anagrams together while preserving original word order wi"
         },
         {
           "case_id": "exact_literal",
           "ok": true,
-          "latency_ms": 8909,
+          "latency_ms": 420,
           "detail": "ok",
           "output_preview": "OK_7F3C"
         },
         {
           "case_id": "exact_literal_alt",
           "ok": true,
-          "latency_ms": 705,
+          "latency_ms": 450,
           "detail": "ok",
           "output_preview": "PASS_TOKEN_91A"
         },
         {
           "case_id": "exact_literal_short",
           "ok": true,
-          "latency_ms": 619,
+          "latency_ms": 359,
           "detail": "ok",
           "output_preview": "A1"
         },
         {
           "case_id": "codeblock_sum_list",
           "ok": true,
-          "latency_ms": 1626,
+          "latency_ms": 1407,
           "detail": "ok",
           "output_preview": "```python\\ndef sum_positive(nums: list[int]) -> int:\\n    return sum(x for x in nums if x > 0)\\n\\nassert sum_positive([-1, 2, -3, 4, 0, 5]) == 11\\n```"
         },
         {
           "case_id": "codeblock_reverse_words",
           "ok": true,
-          "latency_ms": 2537,
+          "latency_ms": 1869,
           "detail": "ok",
-          "output_preview": "```python\\ndef reverse_words(s: str) -> str:\\n    return \" \".join(s.split()[::-1])\\n\\nassert reverse_words(\"the sky is blue\") == \"blue is sky the\"\\n```"
+          "output_preview": "```python\\ndef reverse_words(s: str) -> str:\\n    \"\"\"\\n    Reverses the order of words in a string. \\n    Words are defined as sequences of non-space characters.\\n    \"\"\"\\n    return \" \""
         },
         {
           "case_id": "codeblock_palindrome",
           "ok": true,
-          "latency_ms": 2925,
+          "latency_ms": 1765,
           "detail": "ok",
           "output_preview": "```python\\ndef is_palindrome(s: str) -> bool:\\n    \"\"\"Checks if a string is a palindrome.\"\"\"\\n    clean_s = \"\".join(char.lower() for char in s if char.isalnum())\\n    return clean_s =="
         }

--- a/scripts/output/model-baseline/baseline.harness.gemma.10cases.z490.md
+++ b/scripts/output/model-baseline/baseline.harness.gemma.10cases.z490.md
@@ -1,0 +1,25 @@
+# OpenTerminal Model Baseline
+
+- generated_at: `2026-05-11T15:44:28Z`
+- cases: `scripts/model_baseline_cases.json`
+- mode: `harness`
+
+## gemma
+
+- endpoint: `via-codex-gemma`
+- model_id: `codex-gemma-policy-path`
+- compliance: `10/10` (100.0%)
+- avg_latency_ms: `4840`
+
+| case | ok | latency_ms | detail |
+|---|---:|---:|---|
+| `codeblock_only` | `True` | `1045` | ok |
+| `codeblock_factorial` | `True` | `3320` | ok |
+| `group_anagrams_contract` | `True` | `10732` | ok |
+| `group_anagrams_contract_repeat` | `True` | `15986` | ok |
+| `exact_literal` | `True` | `8909` | ok |
+| `exact_literal_alt` | `True` | `705` | ok |
+| `exact_literal_short` | `True` | `619` | ok |
+| `codeblock_sum_list` | `True` | `1626` | ok |
+| `codeblock_reverse_words` | `True` | `2537` | ok |
+| `codeblock_palindrome` | `True` | `2925` | ok |

--- a/scripts/output/model-baseline/baseline.harness.gemma.10cases.z490.md
+++ b/scripts/output/model-baseline/baseline.harness.gemma.10cases.z490.md
@@ -1,6 +1,6 @@
 # OpenTerminal Model Baseline
 
-- generated_at: `2026-05-11T15:44:28Z`
+- generated_at: `2026-05-11T15:52:12Z`
 - cases: `scripts/model_baseline_cases.json`
 - mode: `harness`
 
@@ -9,17 +9,18 @@
 - endpoint: `via-codex-gemma`
 - model_id: `codex-gemma-policy-path`
 - compliance: `10/10` (100.0%)
-- avg_latency_ms: `4840`
+- avg_latency_ms: `2632`
 
 | case | ok | latency_ms | detail |
 |---|---:|---:|---|
-| `codeblock_only` | `True` | `1045` | ok |
-| `codeblock_factorial` | `True` | `3320` | ok |
-| `group_anagrams_contract` | `True` | `10732` | ok |
-| `group_anagrams_contract_repeat` | `True` | `15986` | ok |
-| `exact_literal` | `True` | `8909` | ok |
-| `exact_literal_alt` | `True` | `705` | ok |
-| `exact_literal_short` | `True` | `619` | ok |
-| `codeblock_sum_list` | `True` | `1626` | ok |
-| `codeblock_reverse_words` | `True` | `2537` | ok |
-| `codeblock_palindrome` | `True` | `2925` | ok |
+| `codeblock_only` | `True` | `1083` | ok |
+| `codeblock_factorial` | `True` | `2751` | ok |
+| `group_anagrams_contract` | `True` | `8109` | ok |
+| `group_anagrams_contract_repeat` | `True` | `8116` | ok |
+| `exact_literal` | `True` | `420` | ok |
+| `exact_literal_alt` | `True` | `450` | ok |
+| `exact_literal_short` | `True` | `359` | ok |
+| `codeblock_sum_list` | `True` | `1407` | ok |
+| `codeblock_reverse_words` | `True` | `1869` | ok |
+| `codeblock_palindrome` | `True` | `1765` | ok |
+

--- a/scripts/output/model-baseline/baseline.harness.gemma.json
+++ b/scripts/output/model-baseline/baseline.harness.gemma.json
@@ -1,0 +1,42 @@
+{
+  "report_type": "open-terminal-model-baseline",
+  "generated_at": "2026-05-11T13:21:59Z",
+  "cases_path": "scripts/model_baseline_cases.json",
+  "mode": "harness",
+  "models": {
+    "gemma": {
+      "status": "ok",
+      "endpoint": "via-codex-gemma",
+      "model_id": "codex-gemma-policy-path",
+      "summary": {
+        "passed": 3,
+        "total": 3,
+        "compliance_percent": 100.0,
+        "avg_latency_ms": 3693
+      },
+      "results": [
+        {
+          "case_id": "codeblock_only",
+          "ok": true,
+          "latency_ms": 1062,
+          "detail": "ok",
+          "output_preview": "```python\\ndef add(a: int, b: int) -> int:\\n    return a + b\\n\\nassert add(2, 3) == 5\\n```"
+        },
+        {
+          "case_id": "group_anagrams_contract",
+          "ok": true,
+          "latency_ms": 9561,
+          "detail": "ok",
+          "output_preview": "```python\\nfrom collections import OrderedDict\\n\\ndef group_anagrams(words: list[str]) -> list[list[str]]:\\n    \"\"\"\\n    Groups anagrams together from a list of words.\\n    \\n    Groups a"
+        },
+        {
+          "case_id": "exact_literal",
+          "ok": true,
+          "latency_ms": 457,
+          "detail": "ok",
+          "output_preview": "OK_7F3C"
+        }
+      ]
+    }
+  }
+}

--- a/scripts/output/model-baseline/baseline.harness.gemma.md
+++ b/scripts/output/model-baseline/baseline.harness.gemma.md
@@ -1,0 +1,18 @@
+# OpenTerminal Model Baseline
+
+- generated_at: `2026-05-11T13:21:59Z`
+- cases: `scripts/model_baseline_cases.json`
+- mode: `harness`
+
+## gemma
+
+- endpoint: `via-codex-gemma`
+- model_id: `codex-gemma-policy-path`
+- compliance: `3/3` (100.0%)
+- avg_latency_ms: `3693`
+
+| case | ok | latency_ms | detail |
+|---|---:|---:|---|
+| `codeblock_only` | `True` | `1062` | ok |
+| `group_anagrams_contract` | `True` | `9561` | ok |
+| `exact_literal` | `True` | `457` | ok |

--- a/scripts/output/model-baseline/baseline.latest.json
+++ b/scripts/output/model-baseline/baseline.latest.json
@@ -1,0 +1,46 @@
+{
+  "report_type": "open-terminal-model-baseline",
+  "generated_at": "2026-05-11T13:00:00Z",
+  "cases_path": "scripts/model_baseline_cases.json",
+  "models": {
+    "gemma": {
+      "status": "unreachable",
+      "endpoint": "http://127.0.0.1:8000/v1",
+      "error": "<urlopen error [Errno 111] Connection refused>"
+    },
+    "qwen2": {
+      "status": "ok",
+      "endpoint": "http://127.0.0.1:8091/v1",
+      "model_id": "Qwen3.6-27B-Q4_K_M.gguf",
+      "summary": {
+        "passed": 3,
+        "total": 3,
+        "compliance_percent": 100.0,
+        "avg_latency_ms": 10948
+      },
+      "results": [
+        {
+          "case_id": "codeblock_only",
+          "ok": true,
+          "latency_ms": 2458,
+          "detail": "ok",
+          "output_preview": "```python\\ndef add(a: int, b: int) -> int:\\n    return a + b\\n\\nassert add(2, 3) == 5\\n```"
+        },
+        {
+          "case_id": "group_anagrams_contract",
+          "ok": true,
+          "latency_ms": 29444,
+          "detail": "ok",
+          "output_preview": "```python\\ndef group_anagrams(words: list[str]) -> list[list[str]]:\\n    \"\"\"\\n    Group anagrams together from a list of words.\\n    \\n    - Anagrams are grouped case-insensitively.\\n   "
+        },
+        {
+          "case_id": "exact_literal",
+          "ok": true,
+          "latency_ms": 943,
+          "detail": "ok",
+          "output_preview": "OK_7F3C"
+        }
+      ]
+    }
+  }
+}

--- a/scripts/output/model-baseline/baseline.latest.md
+++ b/scripts/output/model-baseline/baseline.latest.md
@@ -1,0 +1,23 @@
+# OpenTerminal Model Baseline
+
+- generated_at: `2026-05-11T13:00:00Z`
+- cases: `scripts/model_baseline_cases.json`
+
+## gemma
+
+- endpoint: `http://127.0.0.1:8000/v1`
+- status: unreachable
+- error: `<urlopen error [Errno 111] Connection refused>`
+
+## qwen2
+
+- endpoint: `http://127.0.0.1:8091/v1`
+- model_id: `Qwen3.6-27B-Q4_K_M.gguf`
+- compliance: `3/3` (100.0%)
+- avg_latency_ms: `10948`
+
+| case | ok | latency_ms | detail |
+|---|---:|---:|---|
+| `codeblock_only` | `True` | `2458` | ok |
+| `group_anagrams_contract` | `True` | `29444` | ok |
+| `exact_literal` | `True` | `943` | ok |

--- a/scripts/output/model-baseline/baseline.qwen-only.json
+++ b/scripts/output/model-baseline/baseline.qwen-only.json
@@ -1,0 +1,41 @@
+{
+  "report_type": "open-terminal-model-baseline",
+  "generated_at": "2026-05-11T13:01:21Z",
+  "cases_path": "scripts/model_baseline_cases.json",
+  "models": {
+    "qwen2": {
+      "status": "ok",
+      "endpoint": "http://127.0.0.1:8091/v1",
+      "model_id": "Qwen3.6-27B-Q4_K_M.gguf",
+      "summary": {
+        "passed": 3,
+        "total": 3,
+        "compliance_percent": 100.0,
+        "avg_latency_ms": 10952
+      },
+      "results": [
+        {
+          "case_id": "codeblock_only",
+          "ok": true,
+          "latency_ms": 3136,
+          "detail": "ok",
+          "output_preview": "```python\\ndef add(a: int, b: int) -> int:\\n    return a + b\\n\\nassert add(2, 3) == 5\\n```"
+        },
+        {
+          "case_id": "group_anagrams_contract",
+          "ok": true,
+          "latency_ms": 28779,
+          "detail": "ok",
+          "output_preview": "```python\\ndef group_anagrams(words: list[str]) -> list[list[str]]:\\n    \"\"\"\\n    Group anagrams together from a list of words.\\n    \\n    - Anagrams are grouped case-insensitively.\\n   "
+        },
+        {
+          "case_id": "exact_literal",
+          "ok": true,
+          "latency_ms": 941,
+          "detail": "ok",
+          "output_preview": "OK_7F3C"
+        }
+      ]
+    }
+  }
+}

--- a/scripts/output/model-baseline/baseline.qwen-only.md
+++ b/scripts/output/model-baseline/baseline.qwen-only.md
@@ -1,0 +1,17 @@
+# OpenTerminal Model Baseline
+
+- generated_at: `2026-05-11T13:01:21Z`
+- cases: `scripts/model_baseline_cases.json`
+
+## qwen2
+
+- endpoint: `http://127.0.0.1:8091/v1`
+- model_id: `Qwen3.6-27B-Q4_K_M.gguf`
+- compliance: `3/3` (100.0%)
+- avg_latency_ms: `10952`
+
+| case | ok | latency_ms | detail |
+|---|---:|---:|---|
+| `codeblock_only` | `True` | `3136` | ok |
+| `group_anagrams_contract` | `True` | `28779` | ok |
+| `exact_literal` | `True` | `941` | ok |

--- a/scripts/setup-local.sh
+++ b/scripts/setup-local.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VENV_DIR="$ROOT_DIR/.venv"
+CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/open-terminal"
+STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/open-terminal"
+
+mkdir -p "$CONFIG_DIR" "$STATE_DIR/logs"
+
+if [[ ! -f "$ROOT_DIR/.env" ]]; then
+  cp "$ROOT_DIR/.env.example" "$ROOT_DIR/.env"
+fi
+
+if [[ ! -d "$VENV_DIR" ]]; then
+  uv venv "$VENV_DIR"
+fi
+
+uv pip install --python "$VENV_DIR/bin/python" -e "$ROOT_DIR"
+
+if [[ ! -f "$CONFIG_DIR/api_key" ]]; then
+  umask 077
+  python3 - <<'PY'
+import secrets
+from pathlib import Path
+path = Path.home() / ".config" / "open-terminal" / "api_key"
+path.parent.mkdir(parents=True, exist_ok=True)
+path.write_text(secrets.token_urlsafe(48) + "\n", encoding="utf-8")
+PY
+  chmod 600 "$CONFIG_DIR/api_key"
+fi
+
+{
+  echo -n "OPEN_TERMINAL_API_KEY="
+  tr -d '\r\n' < "$CONFIG_DIR/api_key"
+  echo
+} > "$CONFIG_DIR/api_key.env"
+chmod 600 "$CONFIG_DIR/api_key.env"
+
+echo "Local setup complete."
+echo "Next: scripts/install-user-service.sh"

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+systemctl --user start open-terminal
+systemctl --user --no-pager status open-terminal

--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+systemctl --user --no-pager status open-terminal

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+systemctl --user stop open-terminal
+systemctl --user --no-pager status open-terminal || true

--- a/scripts/verify-decoupled-stack.sh
+++ b/scripts/verify-decoupled-stack.sh
@@ -23,8 +23,17 @@ check_systemd() {
 }
 
 check_open_terminal_health() {
-  local out
-  if out="$(curl -fsS http://127.0.0.1:8010/health 2>/dev/null)" && [[ "$out" == *'"status":"ok"'* ]]; then
+  local out=""
+  local ok=0
+  local i
+  for i in 1 2 3 4 5; do
+    if out="$(curl -fsS http://127.0.0.1:8010/health 2>/dev/null)" && [[ "$out" == *'"status":"ok"'* ]]; then
+      ok=1
+      break
+    fi
+    sleep 1
+  done
+  if [[ "$ok" -eq 1 ]]; then
     pass "OpenTerminal health endpoint is OK"
   else
     fail "OpenTerminal health endpoint failed"
@@ -62,8 +71,17 @@ check_open_terminal_execute() {
 }
 
 check_openwebui_health() {
-  local out
-  if out="$(curl -fsS http://127.0.0.1:8080/health 2>/dev/null)" && [[ "$out" == *'"status":true'* ]]; then
+  local out=""
+  local ok=0
+  local i
+  for i in 1 2 3 4 5; do
+    if out="$(curl -fsS http://127.0.0.1:8080/health 2>/dev/null)" && [[ "$out" == *'"status":true'* ]]; then
+      ok=1
+      break
+    fi
+    sleep 1
+  done
+  if [[ "$ok" -eq 1 ]]; then
     pass "OpenWebUI health endpoint is OK"
   else
     fail "OpenWebUI health endpoint failed"

--- a/scripts/verify-decoupled-stack.sh
+++ b/scripts/verify-decoupled-stack.sh
@@ -26,7 +26,7 @@ check_open_terminal_health() {
   local out=""
   local ok=0
   local i
-  for i in 1 2 3 4 5; do
+  for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
     if out="$(curl -fsS http://127.0.0.1:8010/health 2>/dev/null)" && [[ "$out" == *'"status":"ok"'* ]]; then
       ok=1
       break
@@ -74,7 +74,7 @@ check_openwebui_health() {
   local out=""
   local ok=0
   local i
-  for i in 1 2 3 4 5; do
+  for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
     if out="$(curl -fsS http://127.0.0.1:8080/health 2>/dev/null)" && [[ "$out" == *'"status":true'* ]]; then
       ok=1
       break

--- a/scripts/verify-decoupled-stack.sh
+++ b/scripts/verify-decoupled-stack.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass() {
+  echo "PASS: $1"
+  PASS_COUNT=$((PASS_COUNT + 1))
+}
+
+fail() {
+  echo "FAIL: $1"
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+}
+
+check_systemd() {
+  if systemctl --user is-active --quiet open-terminal; then
+    pass "open-terminal.service is active"
+  else
+    fail "open-terminal.service is not active"
+  fi
+}
+
+check_open_terminal_health() {
+  local out
+  if out="$(curl -fsS http://127.0.0.1:8010/health 2>/dev/null)" && [[ "$out" == *'"status":"ok"'* ]]; then
+    pass "OpenTerminal health endpoint is OK"
+  else
+    fail "OpenTerminal health endpoint failed"
+  fi
+}
+
+check_open_terminal_execute() {
+  local key id status_json
+  key="$(tr -d '\r\n' < "${XDG_CONFIG_HOME:-$HOME/.config}/open-terminal/api_key")"
+
+  id="$(
+    curl -fsS -X POST http://127.0.0.1:8010/execute \
+      -H "Authorization: Bearer ${key}" \
+      -H 'Content-Type: application/json' \
+      -d '{"command":"pwd && echo verify-decoupled-stack-ok","background":false}' \
+      | sed -n 's/.*"id":"\([^"]*\)".*/\1/p'
+  )"
+
+  if [[ -z "$id" ]]; then
+    fail "OpenTerminal execute did not return process id"
+    return
+  fi
+
+  status_json="$(
+    curl -fsS \
+      -H "Authorization: Bearer ${key}" \
+      "http://127.0.0.1:8010/execute/${id}/status?wait=8"
+  )"
+
+  if [[ "$status_json" == *'"status":"done"'* && "$status_json" == *'"exit_code":0'* && "$status_json" == *'verify-decoupled-stack-ok'* ]]; then
+    pass "OpenTerminal execute/status flow works"
+  else
+    fail "OpenTerminal execute/status flow failed"
+  fi
+}
+
+check_openwebui_health() {
+  local out
+  if out="$(curl -fsS http://127.0.0.1:8080/health 2>/dev/null)" && [[ "$out" == *'"status":true'* ]]; then
+    pass "OpenWebUI health endpoint is OK"
+  else
+    fail "OpenWebUI health endpoint failed"
+  fi
+}
+
+check_openwebui_decoupled() {
+  local env_dump
+  if ! docker ps --format '{{.Names}}' | rg -x 'open-webui' >/dev/null; then
+    fail "OpenWebUI container not running"
+    return
+  fi
+
+  env_dump="$(docker inspect open-webui --format '{{json .Config.Env}}')"
+  if [[ "$env_dump" == *"TERMINAL_SERVER_CONNECTIONS"* ]]; then
+    fail "OpenWebUI still has TERMINAL_SERVER_CONNECTIONS"
+  else
+    pass "OpenWebUI is decoupled from OpenTerminal env config"
+  fi
+}
+
+echo "Running decoupled stack verification..."
+check_systemd
+check_open_terminal_health
+check_open_terminal_execute
+check_openwebui_health
+check_openwebui_decoupled
+
+echo
+echo "Summary: ${PASS_COUNT} passed, ${FAIL_COUNT} failed"
+if [[ "$FAIL_COUNT" -gt 0 ]]; then
+  exit 1
+fi

--- a/systemd/midnight-dust-watcher.service
+++ b/systemd/midnight-dust-watcher.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Midnight DUST Watcher (auto deploy on spendable DUST)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=%h/Projects/open-terminal
+Environment=WATCH_REPO=%h/Projects/ba-midnight/midnight-gateway
+Environment=WATCH_ENV_FILE=%h/.local/share/ba-midnight/probe-wallet-seed.env
+Environment=WATCH_INTERVAL_SEC=120
+Environment=WATCH_MAX_MINUTES=240
+Environment=WATCH_SYNC_TIMEOUT_MS=120000
+Environment=WATCH_DEPLOY_TIMEOUT_MS=180000
+ExecStart=%h/Projects/open-terminal/scripts/midnight-dust-watcher --repo ${WATCH_REPO} --env-file ${WATCH_ENV_FILE} --interval-sec ${WATCH_INTERVAL_SEC} --max-minutes ${WATCH_MAX_MINUTES} --timeout-ms ${WATCH_SYNC_TIMEOUT_MS} --deploy-timeout-ms ${WATCH_DEPLOY_TIMEOUT_MS}
+Restart=on-failure
+RestartSec=15
+
+[Install]
+WantedBy=default.target

--- a/systemd/open-terminal-verify.service
+++ b/systemd/open-terminal-verify.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Verify OpenTerminal/OpenWebUI decoupled stack
+After=network.target
+
+[Service]
+Type=oneshot
+WorkingDirectory=%h/Projects/open-terminal
+ExecStart=%h/Projects/open-terminal/scripts/verify-decoupled-stack.sh

--- a/systemd/open-terminal-verify.timer
+++ b/systemd/open-terminal-verify.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run OpenTerminal/OpenWebUI decoupled stack verification periodically
+
+[Timer]
+OnBootSec=2m
+OnUnitActiveSec=15m
+Persistent=true
+Unit=open-terminal-verify.service
+
+[Install]
+WantedBy=timers.target

--- a/systemd/open-terminal.service
+++ b/systemd/open-terminal.service
@@ -10,6 +10,9 @@ EnvironmentFile=-%h/.config/open-terminal/api_key.env
 ExecStart=%h/Projects/open-terminal/.venv/bin/python -m open_terminal.cli run --host ${OPEN_TERMINAL_HOST} --port ${OPEN_TERMINAL_PORT} --cwd ${OPEN_TERMINAL_CWD} --cors-allowed-origins ${OPEN_TERMINAL_CORS_ALLOWED_ORIGINS}
 Restart=on-failure
 RestartSec=2
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectKernelTunables=true
 
 [Install]
 WantedBy=default.target

--- a/systemd/open-terminal.service
+++ b/systemd/open-terminal.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=OpenTerminal local API harness
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=%h/Projects/open-terminal
+EnvironmentFile=%h/Projects/open-terminal/.env
+EnvironmentFile=-%h/.config/open-terminal/api_key.env
+ExecStart=%h/Projects/open-terminal/.venv/bin/python -m open_terminal.cli run --host ${OPEN_TERMINAL_HOST} --port ${OPEN_TERMINAL_PORT} --cwd ${OPEN_TERMINAL_CWD} --cors-allowed-origins ${OPEN_TERMINAL_CORS_ALLOWED_ORIGINS}
+Restart=on-failure
+RestartSec=2
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
## Summary
- retire `codex-gemma` from active Open Terminal operational usage
- demote the remaining wrapper path to explicit historical-only use
- retire the active `/run`, `/jobs`, and `/job *` codex-gemma surfaces from the CLI

## Why
- `codex-gemma` should no longer act as an implicit pseudo-local-worker path for governed delegation
- local worker routing should target the real endpoint lane or fail closed/pause
- Gemma endpoint health is a separate concern and is intentionally not addressed in this PR

## Scope
- README and baseline docs updated to mark `codex-gemma` historical/deprecated
- `scripts/codex-gemma` gated behind `CODEX_GEMMA_ALLOW_HISTORICAL=1`
- installer and historical benchmark paths now require explicit opt-in
- active CLI job surfaces now fail closed with retirement guidance

## Validation
- `bash -n scripts/open-terminal scripts/install-codex-gemma-cli.sh scripts/codex-gemma scripts/otx-benchmark-crosshost`
- `python3 -m py_compile scripts/model_baseline_suite.py`
- `git diff --check`
