### PR TITLE
fix: make uvicorn's keep-alive timeout configurable, default 75s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Fixed
+
+- 🔌 **`Connection reset by peer` on client tool calls** — uvicorn's default keep-alive timeout (5s) can be shorter than a client's HTTP connection-pool reuse window, so a pooled-but-idle connection gets written to right after the server has already closed it, surfacing as `ConnectionResetError` even though the underlying command completed successfully. `timeout_keep_alive` is now configurable (`OPEN_TERMINAL_UVICORN_TIMEOUT_KEEP_ALIVE` or `uvicorn_timeout_keep_alive` in config.toml) and defaults to 75s.
+
 ## [0.11.34] - 2026-04-08
 
 ### Added

--- a/open_terminal/cli.py
+++ b/open_terminal/cli.py
@@ -128,8 +128,14 @@ def run(
         click.echo(click.style("  └─────────────────────────────────────────────────────────────┘", fg="yellow"))
         click.echo()
 
-    from open_terminal.env import UVICORN_LOOP
-    uvicorn.run("open_terminal.main:app", host=host, port=port, loop=UVICORN_LOOP)
+    from open_terminal.env import UVICORN_LOOP, UVICORN_TIMEOUT_KEEP_ALIVE
+    uvicorn.run(
+        "open_terminal.main:app",
+        host=host,
+        port=port,
+        loop=UVICORN_LOOP,
+        timeout_keep_alive=UVICORN_TIMEOUT_KEEP_ALIVE,
+    )
 
 
 @main.command()

--- a/open_terminal/env.py
+++ b/open_terminal/env.py
@@ -156,6 +156,19 @@ UVICORN_LOOP = os.environ.get(
     config.get("uvicorn_loop", "auto"),
 )
 
+# uvicorn's own default (5s) can be shorter than a client's HTTP
+# connection-pool reuse window, so a pooled-but-idle connection can be
+# written to right after the server has already closed it -- surfacing
+# as a ConnectionResetError on the client even though the underlying
+# command completed successfully. 75s matches gunicorn/nginx's common
+# default and comfortably exceeds most client pool idle timeouts.
+UVICORN_TIMEOUT_KEEP_ALIVE = float(
+    os.environ.get(
+        "OPEN_TERMINAL_UVICORN_TIMEOUT_KEEP_ALIVE",
+        config.get("uvicorn_timeout_keep_alive", 75),
+    )
+)
+
 OPEN_TERMINAL_INFO = os.environ.get(
     "OPEN_TERMINAL_INFO",
     config.get("info", ""),


### PR DESCRIPTION
## Problem

I run open-terminal behind Open WebUI as a tool backend. Occasionally a tool call would fail with `ConnectionResetError`/`Connection reset by peer` even though the underlying command had actually completed successfully.

Root cause: uvicorn's default `timeout_keep_alive` is 5 seconds, which can be shorter than the client's own HTTP connection-pool reuse window. If the client (Open WebUI, or any pooled HTTP client) holds a connection open longer than 5s of idle time and then reuses it, the server has already closed it server-side -- the write lands on a dead socket and the client sees a reset, even though nothing about the request itself was wrong.

## Fix

Adds `OPEN_TERMINAL_UVICORN_TIMEOUT_KEEP_ALIVE` (or `uvicorn_timeout_keep_alive` in `config.toml`), following the exact same pattern as the existing `OPEN_TERMINAL_UVICORN_LOOP` option. Defaults to 75s, matching gunicorn/nginx's common default and comfortably exceeding most client-side pool idle timeouts.

## Testing

No test harness exists in this repo currently, so verified manually: built a venv from this branch (`pip install -e .`), started the server (`open-terminal run`), confirmed it boots cleanly and serves `/health` correctly with the new parameter wired through `uvicorn.run()`. Confirmed `timeout_keep_alive` is a real, documented uvicorn.run() parameter via `inspect.signature`.

Happy to adjust the default or naming convention if you'd prefer something different.