### PR TITLE
fix: process log retention never reached files with no in-memory record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Fixed
+
+- 🔒 **Process log retention never reached files whose in-memory record was gone** — `_cleanup_expired()`'s log-file deletion only ran when a log file *also* had a matching in-memory `BackgroundProcess` record, but that registry is in-memory and resets on every restart, while the JSONL log files themselves live on disk (often a persistent volume) and survive restarts. Any log file older than the last restart was therefore permanently unreachable by that path regardless of age. Confirmed this can retain plaintext secrets indefinitely if a command echoes one to stdout. `_cleanup_expired()` now also sweeps the log directory by file mtime directly (rate-limited to once per 5 minutes), independent of any in-memory record.
+
 ## [0.11.34] - 2026-04-08
 
 ### Added

--- a/open_terminal/main.py
+++ b/open_terminal/main.py
@@ -345,7 +345,7 @@ def _set_session_cwd(session_id: str | None, path: str):
         _session_cwds[session_id] = (path, time.time())
 
 
-from open_terminal.utils.log import log_process, read_log
+from open_terminal.utils.log import log_process, read_log, sweep_expired_log_files_rate_limited
 
 
 
@@ -374,6 +374,17 @@ def _cleanup_expired():
                 os.remove(bp.log_path)
             except OSError:
                 pass
+
+    # The loop above only reaches a log file while its BackgroundProcess
+    # record is still in _processes -- an in-memory dict that resets on
+    # every restart. Log files live on disk (often a persistent volume)
+    # and survive restarts, so a file whose in-memory record is gone was
+    # otherwise permanently unreachable by this function regardless of
+    # age. Sweep the log directory by mtime directly as a backstop,
+    # independent of any in-memory record.
+    sweep_expired_log_files_rate_limited(
+        os.path.join(LOG_DIR, "processes"), PROCESS_LOG_RETENTION
+    )
 
 
 def _get_process(process_id: str) -> BackgroundProcess:

--- a/open_terminal/utils/log.py
+++ b/open_terminal/utils/log.py
@@ -14,6 +14,60 @@ import aiofiles.os
 
 from open_terminal.env import MAX_PROCESS_LOG_SIZE, LOG_FLUSH_INTERVAL, LOG_FLUSH_BUFFER
 
+_last_disk_sweep = 0.0
+_DISK_SWEEP_INTERVAL = 300  # rate-limit: at most once per 5 minutes
+
+
+def sweep_expired_log_files(
+    processes_dir: str, retention: float, now: Optional[float] = None
+) -> list[str]:
+    """Delete ``*.jsonl`` files in *processes_dir* older than *retention* seconds.
+
+    Complements the in-memory-record-based cleanup in ``main.py``'s
+    ``_cleanup_expired()``: that path only reaches a log file while its
+    ``BackgroundProcess`` record is still in memory, but that registry
+    resets on every process restart while the log files themselves live
+    on a persistent volume. A log file older than the last restart is
+    therefore permanently unreachable by that path alone, regardless of
+    age. This reads mtimes directly off disk instead.
+
+    Returns the list of paths actually deleted (for observability/tests).
+    """
+    now = time.time() if now is None else now
+    deleted: list[str] = []
+    try:
+        entries = os.listdir(processes_dir)
+    except OSError:
+        return deleted
+    for name in entries:
+        if not name.endswith(".jsonl"):
+            continue
+        path = os.path.join(processes_dir, name)
+        try:
+            if now - os.path.getmtime(path) > retention:
+                os.remove(path)
+                deleted.append(path)
+        except OSError:
+            pass
+    return deleted
+
+
+def sweep_expired_log_files_rate_limited(processes_dir: str, retention: float) -> list[str]:
+    """Rate-limited wrapper around :func:`sweep_expired_log_files`.
+
+    ``_cleanup_expired()`` runs on every process-status-check request,
+    which can be frequent under active polling -- an unconditional
+    directory listing on every call would add avoidable I/O. This limits
+    the actual disk scan to at most once per *_DISK_SWEEP_INTERVAL*
+    regardless of call frequency.
+    """
+    global _last_disk_sweep
+    now = time.time()
+    if now - _last_disk_sweep < _DISK_SWEEP_INTERVAL:
+        return []
+    _last_disk_sweep = now
+    return sweep_expired_log_files(processes_dir, retention, now=now)
+
 
 class BoundedLogWriter:
     """Async wrapper that rotates the log file when it exceeds a size limit.


### PR DESCRIPTION
## Problem

`_cleanup_expired()`'s log-file deletion only runs when a finished log file *also* has a matching in-memory `BackgroundProcess` record:

```python
for process_id in expired:
    bp = _processes.pop(process_id)
    if bp.log_path and bp.finished_at and now - bp.finished_at > PROCESS_LOG_RETENTION:
        os.remove(bp.log_path)
```

`_processes` is an in-memory dict that resets to empty on every process restart. The JSONL log files under `LOG_DIR/processes/` live on disk (frequently a persistent volume in containerized deployments) and survive restarts. So any log file older than the last restart is permanently unreachable by this cleanup path, regardless of age -- the in-memory record it would need to be found via is simply gone.

I ran into this concretely: a long-forgotten process log (months old) was still sitting on disk, and it contained the plaintext output of a command that had echoed a secret to stdout. `PROCESS_LOG_RETENTION` defaults to 7 days, but nothing was actually enforcing that once the server had restarted even once since that log was written.

## Fix

`_cleanup_expired()` now also sweeps the log directory by file mtime directly (`open_terminal/utils/log.py`'s new `sweep_expired_log_files`), independent of any in-memory record. Since `_cleanup_expired()` runs on every process-status-check request (`/execute` list, individual status polls), the actual directory scan is rate-limited to once per 5 minutes (`sweep_expired_log_files_rate_limited`) to avoid adding a full `os.listdir()` on every request under active polling.

Kept the fix minimal and reactive (piggybacking on the existing `_cleanup_expired()` call sites) rather than introducing new background-task/scheduling infrastructure, since none currently exists in this codebase.

## Testing

No test harness exists in this repo currently, so verified manually and end-to-end:
- Unit-level: confirmed `sweep_expired_log_files` deletes only `.jsonl` files older than the retention window, leaves recent and non-`.jsonl` files alone, and the rate-limited wrapper correctly no-ops on a second immediate call.
- End-to-end: started the real server, manually placed an orphaned `.jsonl` file (old mtime, no in-memory record -- simulating exactly the reported scenario), hit `GET /execute`, confirmed the file was deleted.

Happy to add a `tests/` directory with these as real pytest cases if you'd like that as part of this PR rather than a separate contribution.