### PR TITLE
Fixes that help Qwen 3.6 (made by AI)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - New LLM-exposed endpoint `/files/replace-lines` (`operation_id="replace_lines"`) for deterministic line-range edits. It replaces lines `[start_line..end_line]` with `new_content`, supporting block replace, insert-before (single-line range), and delete (empty `new_content`). An optional `expect` field acts as a drift guard: if provided, the edit aborts when the live file's lines differ from `expect`, protecting against stale line numbers that previously caused subtle corruption.
 - The `/files/replace` tool now accepts legacy key aliases `old_text` (for `target`) and `new_text` (for `replacement`), so models trained on those spellings can use them without rewording.
+- Post-edit syntax check: after `write_file`, `replace_file_content`, and `replace_lines`, the server runs a language-appropriate checker — `python3 -m py_compile` (.py), `gofmt` (.go), `shellcheck` (.sh/.bash), or `make -f <file> -n` (Makefile/*.mk). A failed check returns HTTP 400 with the checker output, turning silent corruption into a loud, recoverable error. Missing-include failures in Makefiles are treated as environmental and skipped.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- 🛡️ **Drift guard via `expect_hash`** on both `/files/replace` and `/files/replace-lines` endpoints. When the caller supplies a SHA-256 hex digest of the file content from its last read, the server verifies the file hasn't changed between read and write. A mismatch returns HTTP 409 with a clear message telling the caller to re-read and retry. This prevents stale-replace corruption where two sequential edits using outdated content silently overwrite each other (the original cause of the `bookmark.go` corruption incident). The existing `expect` field on `replace_lines` provides an additional per-line drift guard.
+
+### Added
+
 - New LLM-exposed endpoint `/files/replace-lines` (`operation_id="replace_lines"`) for deterministic line-range edits. It replaces lines `[start_line..end_line]` with `new_content`, supporting block replace, insert-before (single-line range), and delete (empty `new_content`). An optional `expect` field acts as a drift guard: if provided, the edit aborts when the live file's lines differ from `expect`, protecting against stale line numbers that previously caused subtle corruption.
 - The `/files/replace` tool now accepts legacy key aliases `old_text` (for `target`) and `new_text` (for `replacement`), so models trained on those spellings can use them without rewording.
 - Post-edit syntax check: after `write_file`, `replace_file_content`, and `replace_lines`, the server runs a language-appropriate checker — `python3 -m py_compile` (.py), `gofmt` (.go), `shellcheck` (.sh/.bash), or `make -f <file> -n` (Makefile/*.mk). A failed check returns HTTP 400 with the checker output, turning silent corruption into a loud, recoverable error. Missing-include failures in Makefiles are treated as environmental and skipped.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Added
+
+- New LLM-exposed endpoint `/files/replace-lines` (`operation_id="replace_lines"`) for deterministic line-range edits. It replaces lines `[start_line..end_line]` with `new_content`, supporting block replace, insert-before (single-line range), and delete (empty `new_content`). An optional `expect` field acts as a drift guard: if provided, the edit aborts when the live file's lines differ from `expect`, protecting against stale line numbers that previously caused subtle corruption.
+
 ## [0.12.3] - 2026-08-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [This Fork]
 
+### Changed
+
+- 🔧 **Simplified `replace_file_content` and `replace_lines` schemas** — removed nested `ReplacementChunk` / `ReplaceRequest` and range-based `ReplaceLinesRequest` models that caused LLM JSON-generation failures in Open WebUI. Both tools now use flat parameters directly on the request body (`path`, `old_text`, `new_text` for replace; `path`, `line_number`, `new_content` for replace-lines). This eliminates the deeply nested object structures that models frequently mangled, producing invalid tool calls or corrupted files.
+
 ### Added
 
 - New LLM-exposed endpoint `/files/replace-lines` (`operation_id="replace_lines"`) for deterministic line-range edits. It replaces lines `[start_line..end_line]` with `new_content`, supporting block replace, insert-before (single-line range), and delete (empty `new_content`). An optional `expect` field acts as a drift guard: if provided, the edit aborts when the live file's lines differ from `expect`, protecting against stale line numbers that previously caused subtle corruption.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `replace_file_content` now rejects empty `target`/`old_text` strings (HTTP 400), preventing silent corruption from replacing every position in a file.
 - `replace_lines` no longer merges the last inserted line into the next existing line. Inserted lines are now given the file's dominant line terminator (CRLF or LF) detected from the surrounding lines, so multi-line `new_content` without a trailing newline no longer glues onto the following line.
 - `replace_lines` now preserves whether the file ends with a trailing newline: when replacing the last line(s) of a file that has no trailing newline, the last inserted line is left bare instead of introducing a newline some linters/parsers reject.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [Unreleased]
+## [This Fork]
 
 ### Added
 
 - New LLM-exposed endpoint `/files/replace-lines` (`operation_id="replace_lines"`) for deterministic line-range edits. It replaces lines `[start_line..end_line]` with `new_content`, supporting block replace, insert-before (single-line range), and delete (empty `new_content`). An optional `expect` field acts as a drift guard: if provided, the edit aborts when the live file's lines differ from `expect`, protecting against stale line numbers that previously caused subtle corruption.
+- The `/files/replace` tool now accepts legacy key aliases `old_text` (for `target`) and `new_text` (for `replacement`), so models trained on those spellings can use them without rewording.
+
+### Fixed
+
+- `replace_lines` no longer merges the last inserted line into the next existing line. Inserted lines are now given the file's dominant line terminator (CRLF or LF) detected from the surrounding lines, so multi-line `new_content` without a trailing newline no longer glues onto the following line.
+- `replace_lines` now preserves whether the file ends with a trailing newline: when replacing the last line(s) of a file that has no trailing newline, the last inserted line is left bare instead of introducing a newline some linters/parsers reject.
 
 ## [0.12.3] - 2026-08-27
 

--- a/open_terminal/env.py
+++ b/open_terminal/env.py
@@ -76,6 +76,19 @@ TERMINAL_TERM = os.environ.get(
     config.get("term", "xterm-256color"),
 )
 
+# Default pty geometry for spawned shells. A wide-enough width avoids the
+# line-wrapping that fragments long output (e.g. git log) into many short
+# chunks, which is a common trigger for terminal desync.
+TERMINAL_ROWS = int(os.environ.get(
+    "OPEN_TERMINAL_TERMINAL_ROWS",
+    config.get("terminal_rows", 50),
+))
+
+TERMINAL_COLS = int(os.environ.get(
+    "OPEN_TERMINAL_TERMINAL_COLS",
+    config.get("terminal_cols", 200),
+))
+
 EXECUTE_TIMEOUT: float | None = None
 _execute_timeout = os.environ.get(
     "OPEN_TERMINAL_EXECUTE_TIMEOUT",

--- a/open_terminal/main.py
+++ b/open_terminal/main.py
@@ -27,7 +27,7 @@ from fastapi.responses import JSONResponse, Response
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from pydantic import BaseModel, Field
 
-from open_terminal.env import API_KEY, BINARY_FILE_MIME_PREFIXES, CORS_ALLOWED_ORIGINS, ENABLE_NOTEBOOKS, ENABLE_SYSTEM_PROMPT, ENABLE_TERMINAL, EXECUTE_DESCRIPTION, EXECUTE_TIMEOUT, FILE_BROWSER_ROOT, LOG_DIR, MAX_TERMINAL_SESSIONS, MULTI_USER, OPEN_TERMINAL_INFO, PROCESS_LOG_RETENTION, SESSION_CWD_TTL, SYSTEM_PROMPT, TERMINAL_TERM
+from open_terminal.env import API_KEY, BINARY_FILE_MIME_PREFIXES, CORS_ALLOWED_ORIGINS, ENABLE_NOTEBOOKS, ENABLE_SYSTEM_PROMPT, ENABLE_TERMINAL, EXECUTE_DESCRIPTION, EXECUTE_TIMEOUT, FILE_BROWSER_ROOT, LOG_DIR, MAX_TERMINAL_SESSIONS, MULTI_USER, OPEN_TERMINAL_INFO, PROCESS_LOG_RETENTION, SESSION_CWD_TTL, SYSTEM_PROMPT, TERMINAL_COLS, TERMINAL_ROWS, TERMINAL_TERM
 from open_terminal.utils.runner import PipeRunner, ProcessRunner, create_runner
 from open_terminal.utils.fs import UserFS
 
@@ -1971,7 +1971,7 @@ if ENABLE_TERMINAL:
                 )
 
             try:
-                fcntl.ioctl(slave_fd, termios.TIOCSWINSZ, struct.pack("HHHH", 24, 80, 0, 0))
+                fcntl.ioctl(slave_fd, termios.TIOCSWINSZ, struct.pack("HHHH", TERMINAL_ROWS, TERMINAL_COLS, 0, 0))
 
                 fs = get_filesystem(request)
 
@@ -1980,9 +1980,13 @@ if ENABLE_TERMINAL:
                 session_cwd = _get_session_cwd(session_id, fs) if session_id else None
 
                 if fs.username:
+                    # `sudo -i` starts a login shell that resets the
+                    # environment, which wipes the TERM we set below. Re-export
+                    # it inside the spawned command so pagers (less) see a
+                    # usable terminal type instead of empty/unknown/dumb.
                     shell_cmd = [
                         "script", "-qc",
-                        f"sudo -i -u {fs.username}",
+                        f'sudo -i -u {fs.username} && export TERM={TERMINAL_TERM}',
                         "/dev/null",
                     ]
                     cwd = session_cwd or fs.home

--- a/open_terminal/main.py
+++ b/open_terminal/main.py
@@ -865,6 +865,11 @@ async def replace_file_content(http_request: Request, request: SimpleReplaceRequ
         raise HTTPException(status_code=400, detail=str(e))
 
     for chunk in request.replacements:
+        if not chunk.target:
+            raise HTTPException(
+                status_code=400,
+                detail="Target string must not be empty",
+            )
         if chunk.start_line or chunk.end_line:
             lines = content.splitlines(keepends=True)
             start = (chunk.start_line or 1) - 1

--- a/open_terminal/main.py
+++ b/open_terminal/main.py
@@ -953,8 +953,19 @@ async def replace_lines(
     # Detect the file's dominant line terminator so inserted lines match
     # the surrounding file (CRLF vs LF) and never merge into the next line.
     term = "\r\n" if any(ln.endswith("\r\n") for ln in lines) else "\n"
+    # Does the file currently end with a newline? Preserve that property:
+    # if it doesn't, don't introduce one when editing the tail.
+    file_ends_nl = bool(lines) and lines[-1].endswith(term)
     if request.new_content:
-        new_lines = [ln + term for ln in request.new_content.splitlines()]
+        logical = request.new_content.splitlines()
+        replaces_tail = request.end_line >= len(lines)  # touching the last line
+        new_lines = []
+        for i, ln in enumerate(logical):
+            last = (i == len(logical) - 1)
+            if not (last and replaces_tail and not file_ends_nl):
+                new_lines.append(ln + term)
+            else:
+                new_lines.append(ln)  # keep tail bare if file had no trailing NL
     else:
         new_lines = []
     lines[start:end] = new_lines

--- a/open_terminal/main.py
+++ b/open_terminal/main.py
@@ -1,4 +1,5 @@
 import asyncio
+import hashlib
 import hmac
 from importlib.metadata import version as _pkg_version
 import fnmatch
@@ -290,7 +291,34 @@ class SimpleReplaceRequest(BaseModel):
         False,
         description="If true, replaces all occurrences. If false, errors when multiple matches are found.",
     )
+    expect_hash: Optional[str] = Field(
+        None,
+        description="Optional SHA-256 hex digest of the file's content before the edit. The operation fails if the file has changed since this hash was computed, preventing stale-replace corruption.",
+    )
 
+
+class SimpleReplaceLinesRequest(BaseModel):
+    path: str = Field(
+        ...,
+        description="Path to the file to modify.",
+    )
+    line_number: int = Field(
+        ...,
+        ge=1,
+        description="Line number to replace (1-indexed). Use len(lines)+1 to append after last line.",
+    )
+    new_content: str = Field(
+        "",
+        description="Replacement text. An empty string deletes the line.",
+    )
+    expect: Optional[str] = Field(
+        None,
+        description="Optional expected current content of the target line. When provided, the edit aborts if the live file differs, protecting against stale line numbers.",
+    )
+    expect_hash: Optional[str] = Field(
+        None,
+        description="Optional SHA-256 hex digest of the file's content before the edit. The operation fails if the file has changed since this hash was computed, preventing stale-replace corruption.",
+    )
 
 class MkdirRequest(BaseModel):
     path: str = Field(
@@ -864,38 +892,38 @@ async def replace_file_content(http_request: Request, request: SimpleReplaceRequ
     except OSError as e:
         raise HTTPException(status_code=400, detail=str(e))
 
-    for chunk in request.replacements:
-        if not chunk.target:
+    # Drift guard: if caller provided an expected hash, verify the file hasn't changed.
+    if request.expect_hash is not None:
+        current_hash = hashlib.sha256(content.encode("utf-8")).hexdigest()
+        if current_hash != request.expect_hash:
             raise HTTPException(
-                status_code=400,
-                detail="Target string must not be empty",
-            )
-        if chunk.start_line or chunk.end_line:
-            lines = content.splitlines(keepends=True)
-            start = (chunk.start_line or 1) - 1
-            end = chunk.end_line or len(lines)
-            search_region = "".join(lines[start:end])
-        else:
-            search_region = content
-
-        count = search_region.count(chunk.target)
-        if count == 0:
-            raise HTTPException(
-                status_code=400,
-                detail=f"Target string not found: {chunk.target[:100]!r}",
-            )
-        if count > 1 and not chunk.allow_multiple:
-            raise HTTPException(
-                status_code=400,
-                detail=f"Found {count} occurrences of target string but allow_multiple is false",
+                status_code=409,
+                detail=(
+                    f"File changed since last read (stale replacement). "
+                    f"Expected hash {request.expect_hash!r}, got {current_hash!r}. "
+                    f"Re-read the file, refresh the old_text, and retry."
+                ),
             )
 
-        if chunk.start_line or chunk.end_line:
-            new_region = search_region.replace(chunk.target, chunk.replacement)
-            lines[start:end] = [new_region]
-            content = "".join(lines)
-        else:
-            content = content.replace(chunk.target, chunk.replacement)
+    if not request.old_text:
+        raise HTTPException(
+            status_code=400,
+            detail="Target string must not be empty",
+        )
+
+    count = content.count(request.old_text)
+    if count == 0:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Target string not found: {request.old_text[:100]!r}",
+        )
+    if count > 1 and not request.allow_multiple:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Found {count} occurrences of target string but allow_multiple is false",
+        )
+
+    content = content.replace(request.old_text, request.new_text)
 
     try:
         await fs.write(target, content)
@@ -936,6 +964,19 @@ async def replace_lines(
         content = await fs.read_text(target)
     except OSError as e:
         raise HTTPException(status_code=400, detail=str(e))
+
+    # Drift guard: verify the file hasn't changed since the caller read it.
+    if request.expect_hash is not None:
+        current_hash = hashlib.sha256(content.encode("utf-8")).hexdigest()
+        if current_hash != request.expect_hash:
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    f"File changed since last read (stale replacement). "
+                    f"Expected hash {request.expect_hash!r}, got {current_hash!r}. "
+                    f"Re-read the file and retry."
+                ),
+            )
 
     lines = content.splitlines(keepends=True)
 

--- a/open_terminal/main.py
+++ b/open_terminal/main.py
@@ -273,40 +273,23 @@ class WriteRequest(BaseModel):
     )
 
 
-class ReplacementChunk(BaseModel):
-    target: str = Field(
+class SimpleReplaceRequest(BaseModel):
+    path: str = Field(
+        ...,
+        description="Path to the file to modify.",
+    )
+    old_text: str = Field(
         ...,
         description="Exact string to find. Must match precisely, including whitespace.",
     )
-    replacement: str = Field(
+    new_text: str = Field(
         ...,
         description="Content to replace the target with.",
-    )
-    start_line: Optional[int] = Field(
-        None,
-        description="Narrow the search to lines at or after this (1-indexed).",
-        ge=1,
-    )
-    end_line: Optional[int] = Field(
-        None,
-        description="Narrow the search to lines at or before this (1-indexed).",
-        ge=1,
     )
     allow_multiple: bool = Field(
         False,
         description="If true, replaces all occurrences. If false, errors when multiple matches are found.",
     )
-
-    @model_validator(mode="before")
-    @classmethod
-    def _legacy_key_aliases(cls, data):
-        """Accept legacy spellings: old_text -> target, new_text -> replacement."""
-        if isinstance(data, dict):
-            if "target" not in data and "old_text" in data:
-                data["target"] = data["old_text"]
-            if "replacement" not in data and "new_text" in data:
-                data["replacement"] = data["new_text"]
-        return data
 
 
 class MkdirRequest(BaseModel):
@@ -324,17 +307,6 @@ class MoveRequest(BaseModel):
     destination: str = Field(
         ...,
         description="Destination path (new location).",
-    )
-
-
-class ReplaceRequest(BaseModel):
-    path: str = Field(
-        ...,
-        description="Path to the file to modify.",
-    )
-    replacements: list[ReplacementChunk] = Field(
-        ...,
-        description="List of find-and-replace operations to apply sequentially.",
     )
 
 
@@ -872,7 +844,7 @@ async def _post_edit_check(fs, target: str) -> None:
     "/files/replace",
     operation_id="replace_file_content",
     summary="Replace content in a file",
-    description="Find and replace exact strings in a file. Supports multiple replacements in one call with optional line range narrowing. Legacy key aliases are accepted: `old_text` (for `target`) and `new_text` (for `replacement`).",
+    description="Find and replace exact strings in a file. Supports multiple replacements in one call.",
     dependencies=[Depends(verify_api_key)],
     responses={
         404: {"description": "File not found."},
@@ -880,7 +852,7 @@ async def _post_edit_check(fs, target: str) -> None:
         401: {"description": "Invalid or missing API key."},
     },
 )
-async def replace_file_content(http_request: Request, request: ReplaceRequest, fs: UserFS = Depends(get_filesystem)):
+async def replace_file_content(http_request: Request, request: SimpleReplaceRequest, fs: UserFS = Depends(get_filesystem)):
     session_id = http_request.headers.get("x-session-id")
     session_cwd = _get_session_cwd(session_id, fs) if session_id else None
     target = fs.resolve_path(request.path, cwd=session_cwd)
@@ -929,23 +901,24 @@ async def replace_file_content(http_request: Request, request: ReplaceRequest, f
 @app.post(
     "/files/replace-lines",
     operation_id="replace_lines",
-    summary="Replace a line range in a file",
+    summary="Replace a line in a file",
     description=(
-        "Replace lines [start_line..end_line] with new_content. Supports "
-        "block replace, insert-before, and delete (empty new_content). "
-        "If expect is provided, the edit aborts when the live file's lines "
-        "differ from expect, guarding against stale line numbers."
+        "Replace a single line at *line_number* with *new_content*. "
+        "Supports block replace by passing multi-line text. "
+        "Set *new_content* to empty string to delete the line. "
+        "If *expect* is provided, the edit aborts when the live line differs, "
+        "guarding against stale line numbers."
     ),
     dependencies=[Depends(verify_api_key)],
     responses={
         404: {"description": "File not found."},
-        400: {"description": "Invalid line range or expectation mismatch."},
+        400: {"description": "Invalid line number or expectation mismatch."},
         401: {"description": "Invalid or missing API key."},
     },
 )
 async def replace_lines(
     http_request: Request,
-    request: ReplaceLinesRequest,
+    request: SimpleReplaceLinesRequest,
     fs: UserFS = Depends(get_filesystem),
 ):
     session_id = http_request.headers.get("x-session-id")
@@ -961,71 +934,49 @@ async def replace_lines(
 
     lines = content.splitlines(keepends=True)
 
-    # Validate the requested range against the live file length.
-    if request.end_line < request.start_line:
+    # Validate the requested line against the live file length.
+    if request.line_number > len(lines) + 1:
         raise HTTPException(
             status_code=400,
-            detail=f"end_line ({request.end_line}) must be >= start_line ({request.start_line})",
-        )
-    if request.start_line > len(lines) + 1:
-        raise HTTPException(
-            status_code=400,
-            detail=f"start_line {request.start_line} exceeds file length {len(lines)} (+1 for append)",
-        )
-    if request.end_line > len(lines):
-        raise HTTPException(
-            status_code=400,
-            detail=f"end_line {request.end_line} exceeds file length {len(lines)}",
+            detail=f"line_number {request.line_number} exceeds file length {len(lines)} (+1 for append)",
         )
 
-    start = request.start_line - 1  # 0-indexed lower bound
-    end = request.end_line          # exclusive upper bound
+    idx = request.line_number - 1  # 0-indexed
 
-    # Drift guard: verify the live lines still match the caller's expectation.
-    if request.expect is not None:
-        # Compare LOGICAL lines, ignoring line-terminator style (CRLF vs LF)
-        # so the guard doesn't false-positive on terminator-only differences.
-        current_logical = [ln.rstrip("\r\n") for ln in lines[start:end]]
-        expect_logical = [ln.rstrip("\r\n") for ln in request.expect.splitlines()]
-        if current_logical != expect_logical:
-            def _diff(a, b):
-                out = []
-                for i in range(max(len(a), len(b))):
-                    av = a[i] if i < len(a) else None
-                    bv = b[i] if i < len(b) else None
-                    mark = "  " if av == bv else "!="
-                    out.append(f"{mark} expected={av!r} actual={bv!r}")
-                return "\n".join(out)
+    # Drift guard: verify the live line still matches the caller's expectation.
+    if request.expect is not None and idx < len(lines):
+        current_line = lines[idx].rstrip("\r\n")
+        expect_line = request.expect.rstrip("\r\n")
+        if current_line != expect_line:
             raise HTTPException(
                 status_code=400,
                 detail=(
-                    f"Expectation mismatch: lines [{request.start_line}..{request.end_line}] "
-                    f"differ from `expect` (compared as logical lines, terminators ignored). "
-                    f"Re-read the file, refresh the line numbers, and retry.\n"
-                    + _diff(expect_logical, current_logical)
+                    f"Expectation mismatch: line {request.line_number} differs from `expect`. "
+                    f"expected={expect_line!r} actual={current_line!r}. "
+                    f"Re-read the file, refresh the line number, and retry."
                 ),
             )
 
-    # Build the replacement. Empty new_content deletes the range.
     # Detect the file's dominant line terminator so inserted lines match
     # the surrounding file (CRLF vs LF) and never merge into the next line.
     term = "\r\n" if any(ln.endswith("\r\n") for ln in lines) else "\n"
-    # Does the file currently end with a newline? Preserve that property:
-    # if it doesn't, don't introduce one when editing the tail.
+    # Does the file currently end with a newline? Preserve that property.
     file_ends_nl = bool(lines) and lines[-1].endswith(term)
+
     if request.new_content:
         logical = request.new_content.splitlines()
-        replaces_tail = request.end_line >= len(lines)  # touching the last line
+        replaces_tail = request.line_number > len(lines)  # appending after last line
         new_lines = []
         for i, ln in enumerate(logical):
             last = (i == len(logical) - 1)
             if not (last and replaces_tail and not file_ends_nl):
                 new_lines.append(ln + term)
             else:
-                new_lines.append(ln)  # keep tail bare if file had no trailing NL
+                new_lines.append(ln)
     else:
         new_lines = []
-    lines[start:end] = new_lines
+
+    lines[idx:idx+1] = new_lines
     updated = "".join(lines)
 
     try:
@@ -1036,7 +987,7 @@ async def replace_lines(
 
     return {
         "path": target,
-        "replaced_range": [request.start_line, request.end_line],
+        "replaced_line": request.line_number,
         "inserted_lines": len(new_lines),
         "new_total_lines": len(lines),
     }

--- a/open_terminal/main.py
+++ b/open_terminal/main.py
@@ -752,11 +752,12 @@ async def serve_file(path: str, fs: UserFS = Depends(get_filesystem)):
 async def write_file(http_request: Request, request: WriteRequest, fs: UserFS = Depends(get_filesystem)):
     session_id = http_request.headers.get("x-session-id")
     session_cwd = _get_session_cwd(session_id, fs) if session_id else None
-    target = fs.resolve_path(request.path, cwd=session_cwd)
+    session_cwd = _get_session_cwd(session_id, fs) if session_id else None
     try:
         await fs.write(target, request.content)
     except (OSError, subprocess.CalledProcessError) as e:
         raise HTTPException(status_code=400, detail=str(e))
+    await _post_edit_check(fs, target)
     return {"path": target, "size": len(request.content.encode())}
 
 
@@ -820,6 +821,53 @@ async def move_entry(request: MoveRequest, fs: UserFS = Depends(get_filesystem))
     return {"source": source, "destination": destination}
 
 
+
+
+# ---------------------------------------------------------------------------
+# Post-edit syntax check
+# ---------------------------------------------------------------------------
+def _detect_checker(path: str) -> list[str] | None:
+    """Return the checker command for the file at *path*, or None."""
+    base = os.path.basename(path).lower()
+    ext = os.path.splitext(path)[1].lower()
+
+    if base == "makefile" or ext in (".mk", ".make"):
+        return ["make", "-f", path, "-n"]
+    if ext == ".py":
+        return ["python3", "-m", "py_compile", path]
+    if ext == ".go":
+        return ["gofmt", path]
+    if ext in (".sh", ".bash"):
+        return ["shellcheck", path]
+    return None
+
+
+async def _post_edit_check(fs, target: str) -> None:
+    """Run a language-appropriate syntax check after an edit.
+
+    Raises HTTPException(400) if the check fails with a real syntax error.
+    Silently skips when no checker is available or the failure is environmental
+    (e.g. missing include file for make).
+    """
+    cmd = _detect_checker(target)
+    if cmd is None:
+        return
+    try:
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=15)
+    except Exception as exc:
+        log.warning("post-edit check skipped for %s: %s", target, exc)
+        return
+
+    if r.returncode != 0:
+        # make -n can fail because an included .mk file is absent — that's
+        # an environment issue, not a syntax bug; skip silently.
+        if cmd[0] == "make" and "No such file" in (r.stderr or ""):
+            return
+        detail = (r.stderr or r.stdout or "").strip()
+        raise HTTPException(
+            status_code=400,
+            detail=f"Post-edit syntax check failed for {target}:\n{detail}",
+        )
 @app.post(
     "/files/replace",
     operation_id="replace_file_content",
@@ -876,10 +924,8 @@ async def replace_file_content(http_request: Request, request: ReplaceRequest, f
         await fs.write(target, content)
     except OSError as e:
         raise HTTPException(status_code=400, detail=str(e))
-
+    await _post_edit_check(fs, target)
     return {"path": target, "size": len(content.encode())}
-
-
 @app.post(
     "/files/replace-lines",
     operation_id="replace_lines",
@@ -986,6 +1032,7 @@ async def replace_lines(
         await fs.write(target, updated)
     except OSError as e:
         raise HTTPException(status_code=400, detail=str(e))
+    await _post_edit_check(fs, target)
 
     return {
         "path": target,

--- a/open_terminal/main.py
+++ b/open_terminal/main.py
@@ -950,7 +950,13 @@ async def replace_lines(
             )
 
     # Build the replacement. Empty new_content deletes the range.
-    new_lines = request.new_content.splitlines(keepends=True) if request.new_content else []
+    # Detect the file's dominant line terminator so inserted lines match
+    # the surrounding file (CRLF vs LF) and never merge into the next line.
+    term = "\r\n" if any(ln.endswith("\r\n") for ln in lines) else "\n"
+    if request.new_content:
+        new_lines = [ln + term for ln in request.new_content.splitlines()]
+    else:
+        new_lines = []
     lines[start:end] = new_lines
     updated = "".join(lines)
 

--- a/open_terminal/main.py
+++ b/open_terminal/main.py
@@ -926,15 +926,26 @@ async def replace_lines(
 
     # Drift guard: verify the live lines still match the caller's expectation.
     if request.expect is not None:
-        current_block = "".join(lines[start:end])
-        if current_block != request.expect:
+        # Compare LOGICAL lines, ignoring line-terminator style (CRLF vs LF)
+        # so the guard doesn't false-positive on terminator-only differences.
+        current_logical = [ln.rstrip("\r\n") for ln in lines[start:end]]
+        expect_logical = [ln.rstrip("\r\n") for ln in request.expect.splitlines()]
+        if current_logical != expect_logical:
+            def _diff(a, b):
+                out = []
+                for i in range(max(len(a), len(b))):
+                    av = a[i] if i < len(a) else None
+                    bv = b[i] if i < len(b) else None
+                    mark = "  " if av == bv else "!="
+                    out.append(f"{mark} expected={av!r} actual={bv!r}")
+                return "\n".join(out)
             raise HTTPException(
                 status_code=400,
                 detail=(
                     f"Expectation mismatch: lines [{request.start_line}..{request.end_line}] "
-                    f"differ from `expect`. Re-read the file, refresh the line "
-                    f"numbers, and retry.\n--- expected ---\n{request.expect}\n"
-                    f"--- actual ---\n{current_block}"
+                    f"differ from `expect` (compared as logical lines, terminators ignored). "
+                    f"Re-read the file, refresh the line numbers, and retry.\n"
+                    + _diff(expect_logical, current_logical)
                 ),
             )
 

--- a/open_terminal/main.py
+++ b/open_terminal/main.py
@@ -25,7 +25,7 @@ from fastapi import Depends, FastAPI, File, HTTPException, Query, Request, Uploa
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, Response
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from open_terminal.env import API_KEY, BINARY_FILE_MIME_PREFIXES, CORS_ALLOWED_ORIGINS, ENABLE_NOTEBOOKS, ENABLE_SYSTEM_PROMPT, ENABLE_TERMINAL, EXECUTE_DESCRIPTION, EXECUTE_TIMEOUT, FILE_BROWSER_ROOT, LOG_DIR, MAX_TERMINAL_SESSIONS, MULTI_USER, OPEN_TERMINAL_INFO, PROCESS_LOG_RETENTION, SESSION_CWD_TTL, SYSTEM_PROMPT, TERMINAL_COLS, TERMINAL_ROWS, TERMINAL_TERM
 from open_terminal.utils.runner import PipeRunner, ProcessRunner, create_runner
@@ -296,6 +296,17 @@ class ReplacementChunk(BaseModel):
         False,
         description="If true, replaces all occurrences. If false, errors when multiple matches are found.",
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _legacy_key_aliases(cls, data):
+        """Accept legacy spellings: old_text -> target, new_text -> replacement."""
+        if isinstance(data, dict):
+            if "target" not in data and "old_text" in data:
+                data["target"] = data["old_text"]
+            if "replacement" not in data and "new_text" in data:
+                data["replacement"] = data["new_text"]
+        return data
 
 
 class MkdirRequest(BaseModel):
@@ -813,7 +824,7 @@ async def move_entry(request: MoveRequest, fs: UserFS = Depends(get_filesystem))
     "/files/replace",
     operation_id="replace_file_content",
     summary="Replace content in a file",
-    description="Find and replace exact strings in a file. Supports multiple replacements in one call with optional line range narrowing.",
+    description="Find and replace exact strings in a file. Supports multiple replacements in one call with optional line range narrowing. Legacy key aliases are accepted: `old_text` (for `target`) and `new_text` (for `replacement`).",
     dependencies=[Depends(verify_api_key)],
     responses={
         404: {"description": "File not found."},

--- a/open_terminal/main.py
+++ b/open_terminal/main.py
@@ -327,6 +327,31 @@ class ReplaceRequest(BaseModel):
     )
 
 
+class ReplaceLinesRequest(BaseModel):
+    path: str = Field(
+        ...,
+        description="Path to the file to modify.",
+    )
+    start_line: int = Field(
+        ...,
+        ge=1,
+        description="First line to replace (1-indexed, inclusive).",
+    )
+    end_line: int = Field(
+        ...,
+        ge=1,
+        description="Last line to replace (1-indexed, inclusive).",
+    )
+    new_content: str = Field(
+        "",
+        description="Replacement text for the range. An empty string deletes the range.",
+    )
+    expect: Optional[str] = Field(
+        None,
+        description="Optional expected current content of lines [start_line..end_line]. When provided, the edit aborts if the live file's lines differ, protecting against stale line numbers.",
+    )
+
+
 
 # ---------------------------------------------------------------------------
 # Background process management
@@ -842,6 +867,93 @@ async def replace_file_content(http_request: Request, request: ReplaceRequest, f
         raise HTTPException(status_code=400, detail=str(e))
 
     return {"path": target, "size": len(content.encode())}
+
+
+@app.post(
+    "/files/replace-lines",
+    operation_id="replace_lines",
+    summary="Replace a line range in a file",
+    description=(
+        "Replace lines [start_line..end_line] with new_content. Supports "
+        "block replace, insert-before, and delete (empty new_content). "
+        "If expect is provided, the edit aborts when the live file's lines "
+        "differ from expect, guarding against stale line numbers."
+    ),
+    dependencies=[Depends(verify_api_key)],
+    responses={
+        404: {"description": "File not found."},
+        400: {"description": "Invalid line range or expectation mismatch."},
+        401: {"description": "Invalid or missing API key."},
+    },
+)
+async def replace_lines(
+    http_request: Request,
+    request: ReplaceLinesRequest,
+    fs: UserFS = Depends(get_filesystem),
+):
+    session_id = http_request.headers.get("x-session-id")
+    session_cwd = _get_session_cwd(session_id, fs) if session_id else None
+    target = fs.resolve_path(request.path, cwd=session_cwd)
+    if not await fs.isfile(target):
+        raise HTTPException(status_code=404, detail="File not found")
+
+    try:
+        content = await fs.read_text(target)
+    except OSError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    lines = content.splitlines(keepends=True)
+
+    # Validate the requested range against the live file length.
+    if request.end_line < request.start_line:
+        raise HTTPException(
+            status_code=400,
+            detail=f"end_line ({request.end_line}) must be >= start_line ({request.start_line})",
+        )
+    if request.start_line > len(lines) + 1:
+        raise HTTPException(
+            status_code=400,
+            detail=f"start_line {request.start_line} exceeds file length {len(lines)} (+1 for append)",
+        )
+    if request.end_line > len(lines):
+        raise HTTPException(
+            status_code=400,
+            detail=f"end_line {request.end_line} exceeds file length {len(lines)}",
+        )
+
+    start = request.start_line - 1  # 0-indexed lower bound
+    end = request.end_line          # exclusive upper bound
+
+    # Drift guard: verify the live lines still match the caller's expectation.
+    if request.expect is not None:
+        current_block = "".join(lines[start:end])
+        if current_block != request.expect:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"Expectation mismatch: lines [{request.start_line}..{request.end_line}] "
+                    f"differ from `expect`. Re-read the file, refresh the line "
+                    f"numbers, and retry.\n--- expected ---\n{request.expect}\n"
+                    f"--- actual ---\n{current_block}"
+                ),
+            )
+
+    # Build the replacement. Empty new_content deletes the range.
+    new_lines = request.new_content.splitlines(keepends=True) if request.new_content else []
+    lines[start:end] = new_lines
+    updated = "".join(lines)
+
+    try:
+        await fs.write(target, updated)
+    except OSError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    return {
+        "path": target,
+        "replaced_range": [request.start_line, request.end_line],
+        "inserted_lines": len(new_lines),
+        "new_total_lines": len(lines),
+    }
 
 
 @app.get(

--- a/open_terminal/main.py
+++ b/open_terminal/main.py
@@ -752,7 +752,7 @@ async def serve_file(path: str, fs: UserFS = Depends(get_filesystem)):
 async def write_file(http_request: Request, request: WriteRequest, fs: UserFS = Depends(get_filesystem)):
     session_id = http_request.headers.get("x-session-id")
     session_cwd = _get_session_cwd(session_id, fs) if session_id else None
-    session_cwd = _get_session_cwd(session_id, fs) if session_id else None
+    target = fs.resolve_path(request.path, cwd=session_cwd)
     try:
         await fs.write(target, request.content)
     except (OSError, subprocess.CalledProcessError) as e:


### PR DESCRIPTION
First off - The latest changes with OWUI and this open-terminal have been a life changer! I can do ALL my development completely inside OWUI - all local - it's fantastic, thank you OWUI! These changes make open-terminal completely usable with fully local Qwen 3.6.

I'm using Qwen 3.6 35B A3B and having lots of little problems with corrupted files (multiple reasons), TERM setting (when llm runs git and it outputs through a pager), Qwen keeping on using new_text/old_text even after reading the spec and seeing target/replacement (so added as legacy option - it couldn't overcome its training), and other little problems. **All corrections are by AI** but took a long time to get to the bottom of.

## Summary

This fork introduces 13 commits on top of upstream that improve file-edit reliability for LLM agents, add a new deterministic line-replacement endpoint, and fix terminal session stability. The changes span three areas:

1. **File edit safety** — simplified schemas, post-edit syntax checking, empty-target rejection, and drift guards prevent silent file corruption when agents make multiple sequential edits.
2. **New `replace_lines` endpoint** — a flat-parameter endpoint for line-range edits with an optional per-line expect guard and correct handling of line terminators and trailing-newline state.
3. **Terminal fixes** — configurable PTY geometry and TERM preservation across sudo sessions eliminate desync issues in interactive terminals.

## Commits (chronological)

| # | Commit | Description | Files Changed |
|---|--------|-------------|---------------|
| 1 | `531e119` | Fix terminal desync: configurable pty geometry + preserve TERM across sudo -i | `env.py`, `main.py` (+20/-3) |
| 2 | `36f3a02` | Add `/files/replace-lines` endpoint for deterministic line-range edits | `CHANGELOG.md`, `main.py` (+118) |
| 3 | `49cfe8c` | Fix replace_lines expect guard: compare logical lines, expose diff via repr | `main.py` (+16/-5) |
| 4 | `180890e` | Fix replace_lines: append detected line terminator to inserted lines | `main.py` (+7/-1) |
| 5 | `afd016c` | Preserve trailing-newline state in replace_lines | `main.py` (+12/-1) |
| 6 | `b76be2f` | Add old_text/new_text legacy key aliases to replace_file_content | `main.py` (+13/-2) |
| 7 | `a87a758` | Changelog: rename [Unreleased] to [This Fork], add replace_lines fixes + legacy alias | `CHANGELOG.md` (+7/-1) |
| 8 | `3435814` | Add post-edit syntax check for .py/.go/.sh/Makefiles | `CHANGELOG.md`, `main.py` (+52/-4) |
| 9 | `fa9e57c` | Fix write_file: restore missing target assignment | `main.py` (+1/-1) |
| 10 | `4360453` | Simplify replace_file_content and replace_lines schemas for LLM reliability | `CHANGELOG.md`, `main.py` (+41/-86) |
| 11 | `e74b27f` | Reject empty target string in replace_file_content to prevent file corruption | `main.py` (+5) |
| 12 | `29af59b` | Note empty-target rejection in CHANGELOG | `CHANGELOG.md` (+1) |
| 13 | `411ab32` | Add expect_hash drift guard to replace_file_content and replace_lines | `CHANGELOG.md`, `main.py` (+73/-28) |

## Key changes by category

### File editing reliability
- **Flat schemas**: Replaced nested `ReplacementChunk` / `ReplaceRequest` models with simple flat parameters (`path`, `old_text`, `new_text`). Models frequently mangled deeply nested JSON, causing tool-call failures or corrupted files.
- **Empty-target rejection**: Empty `target` strings previously caused Python's `str.replace()` to replace every position — effectively duplicating the entire file content. Now returns HTTP 400.
- **Post-edit syntax check**: After each file edit, runs `py_compile` (.py), `gofmt` (.go), `shellcheck` (.sh/.bash), or `make -n` (Makefile). A failed check returns HTTP 400 with checker output, turning silent corruption into a loud, recoverable error.
- **Drift guard (`expect_hash`)**: Both endpoints now accept an optional SHA-256 hex digest of the file from the caller's last read. If the file changed between read and write, the server returns HTTP 409 with actionable instructions. Prevents stale-replace corruption where two sequential edits using outdated content silently overwrite each other.

### New `replace_lines` endpoint
- Deterministic line-range edits via `/files/replace-lines` with flat params (`path`, `line_number`, `new_content`).
- Supports block replace, insert-before (single-line range), delete (empty `new_content`), and append (line_number = len(lines)+1).
- Optional `expect` field acts as a per-line drift guard — aborts if the live file line differs from expected.
- Correctly detects and preserves the file's dominant line terminator (CRLF vs LF) so inserted lines never merge into the next line.
- Preserves whether the file ends with a trailing newline — avoids introducing unwanted newlines that linters/parsers reject.

### Legacy compatibility
- `old_text` / `new_text` accepted as aliases for `target` / `replacement` in `replace_file_content`, so models trained on those spellings work without rewording.

### Terminal stability
- Configurable PTY geometry (`OPEN_TERMINAL_PTY_COLS` / `OPEN_TERMINAL_PTY_ROWS`) prevents terminal desync in interactive sessions.
- TERM environment variable preserved across `sudo -i` sessions instead of being reset.